### PR TITLE
Fix Error: Cannot resolve module jquery

### DIFF
--- a/1.bundle.js
+++ b/1.bundle.js
@@ -1,18 +1,17 @@
-webpackJsonp([1],
-{
+webpackJsonp([1],{
 
-/***/ 7:
+/***/ 6:
 /***/ function(module, exports, require) {
 
-	/* WEBPACK VAR INJECTION */(function(require, module) {/*! Hammer.JS - v1.0.5 - 2013-04-07
+	var __WEBPACK_AMD_DEFINE_RESULT__;/*! Hammer.JS - v1.0.6 - 2014-01-02
 	 * http://eightmedia.github.com/hammer.js
 	 *
-	 * Copyright (c) 2013 Jorik Tangelder <j.tangelder@gmail.com>;
+	 * Copyright (c) 2014 Jorik Tangelder <j.tangelder@gmail.com>;
 	 * Licensed under the MIT license */
-	
+
 	(function(window, undefined) {
-	    'use strict';
-	
+	  'use strict';
+
 	/**
 	 * Hammer
 	 * use this to create instances
@@ -22,93 +21,326 @@ webpackJsonp([1],
 	 * @constructor
 	 */
 	var Hammer = function(element, options) {
-	    return new Hammer.Instance(element, options || {});
+	  return new Hammer.Instance(element, options || {});
 	};
-	
+
 	// default settings
 	Hammer.defaults = {
-	    // add styles and attributes to the element to prevent the browser from doing
-	    // its native behavior. this doesnt prevent the scrolling, but cancels
-	    // the contextmenu, tap highlighting etc
-	    // set to false to disable this
-	    stop_browser_behavior: {
-			// this also triggers onselectstart=false for IE
-	        userSelect: 'none',
-			// this makes the element blocking in IE10 >, you could experiment with the value
-			// see for more options this issue; https://github.com/EightMedia/hammer.js/issues/241
-	        touchAction: 'none',
-			touchCallout: 'none',
-	        contentZooming: 'none',
-	        userDrag: 'none',
-	        tapHighlightColor: 'rgba(0,0,0,0)'
-	    }
-	
-	    // more settings are defined per gesture at gestures.js
+	  // add styles and attributes to the element to prevent the browser from doing
+	  // its native behavior. this doesnt prevent the scrolling, but cancels
+	  // the contextmenu, tap highlighting etc
+	  // set to false to disable this
+	  stop_browser_behavior: {
+	    // this also triggers onselectstart=false for IE
+	    userSelect       : 'none',
+	    // this makes the element blocking in IE10 >, you could experiment with the value
+	    // see for more options this issue; https://github.com/EightMedia/hammer.js/issues/241
+	    touchAction      : 'none',
+	    touchCallout     : 'none',
+	    contentZooming   : 'none',
+	    userDrag         : 'none',
+	    tapHighlightColor: 'rgba(0,0,0,0)'
+	  }
+
+	  //
+	  // more settings are defined per gesture at gestures.js
+	  //
 	};
-	
+
 	// detect touchevents
-	Hammer.HAS_POINTEREVENTS = navigator.pointerEnabled || navigator.msPointerEnabled;
+	Hammer.HAS_POINTEREVENTS = window.navigator.pointerEnabled || window.navigator.msPointerEnabled;
 	Hammer.HAS_TOUCHEVENTS = ('ontouchstart' in window);
-	
+
 	// dont use mouseevents on mobile devices
-	Hammer.MOBILE_REGEX = /mobile|tablet|ip(ad|hone|od)|android/i;
-	Hammer.NO_MOUSEEVENTS = Hammer.HAS_TOUCHEVENTS && navigator.userAgent.match(Hammer.MOBILE_REGEX);
-	
+	Hammer.MOBILE_REGEX = /mobile|tablet|ip(ad|hone|od)|android|silk/i;
+	Hammer.NO_MOUSEEVENTS = Hammer.HAS_TOUCHEVENTS && window.navigator.userAgent.match(Hammer.MOBILE_REGEX);
+
 	// eventtypes per touchevent (start, move, end)
 	// are filled by Hammer.event.determineEventTypes on setup
 	Hammer.EVENT_TYPES = {};
-	
+
 	// direction defines
 	Hammer.DIRECTION_DOWN = 'down';
 	Hammer.DIRECTION_LEFT = 'left';
 	Hammer.DIRECTION_UP = 'up';
 	Hammer.DIRECTION_RIGHT = 'right';
-	
+
 	// pointer type
 	Hammer.POINTER_MOUSE = 'mouse';
 	Hammer.POINTER_TOUCH = 'touch';
 	Hammer.POINTER_PEN = 'pen';
-	
+
 	// touch event defines
 	Hammer.EVENT_START = 'start';
 	Hammer.EVENT_MOVE = 'move';
 	Hammer.EVENT_END = 'end';
-	
+
 	// hammer document where the base events are added at
-	Hammer.DOCUMENT = document;
-	
-	// plugins namespace
-	Hammer.plugins = {};
-	
+	Hammer.DOCUMENT = window.document;
+
+	// plugins and gestures namespaces
+	Hammer.plugins = Hammer.plugins || {};
+	Hammer.gestures = Hammer.gestures || {};
+
 	// if the window events are set...
 	Hammer.READY = false;
-	
+
 	/**
 	 * setup events to detect gestures on the document
 	 */
 	function setup() {
-	    if(Hammer.READY) {
-	        return;
-	    }
-	
-	    // find what eventtypes we add listeners to
-	    Hammer.event.determineEventTypes();
-	
-	    // Register all gestures inside Hammer.gestures
-	    for(var name in Hammer.gestures) {
-	        if(Hammer.gestures.hasOwnProperty(name)) {
-	            Hammer.detection.register(Hammer.gestures[name]);
-	        }
-	    }
-	
-	    // Add touch events on the document
-	    Hammer.event.onTouch(Hammer.DOCUMENT, Hammer.EVENT_MOVE, Hammer.detection.detect);
-	    Hammer.event.onTouch(Hammer.DOCUMENT, Hammer.EVENT_END, Hammer.detection.detect);
-	
-	    // Hammer is ready...!
-	    Hammer.READY = true;
+	  if(Hammer.READY) {
+	    return;
+	  }
+
+	  // find what eventtypes we add listeners to
+	  Hammer.event.determineEventTypes();
+
+	  // Register all gestures inside Hammer.gestures
+	  Hammer.utils.each(Hammer.gestures, function(gesture){
+	    Hammer.detection.register(gesture);
+	  });
+
+	  // Add touch events on the document
+	  Hammer.event.onTouch(Hammer.DOCUMENT, Hammer.EVENT_MOVE, Hammer.detection.detect);
+	  Hammer.event.onTouch(Hammer.DOCUMENT, Hammer.EVENT_END, Hammer.detection.detect);
+
+	  // Hammer is ready...!
+	  Hammer.READY = true;
 	}
-	
+
+	Hammer.utils = {
+	  /**
+	   * extend method,
+	   * also used for cloning when dest is an empty object
+	   * @param   {Object}    dest
+	   * @param   {Object}    src
+	   * @parm  {Boolean}  merge    do a merge
+	   * @returns {Object}    dest
+	   */
+	  extend: function extend(dest, src, merge) {
+	    for(var key in src) {
+	      if(dest[key] !== undefined && merge) {
+	        continue;
+	      }
+	      dest[key] = src[key];
+	    }
+	    return dest;
+	  },
+
+
+	  /**
+	   * for each
+	   * @param obj
+	   * @param iterator
+	   */
+	  each: function(obj, iterator, context) {
+	    var i, length;
+	    // native forEach on arrays
+	    if ('forEach' in obj) {
+	      obj.forEach(iterator, context);
+	    }
+	    // arrays
+	    else if(obj.length !== undefined) {
+	      for (i = 0, length = obj.length; i < length; i++) {
+	        if (iterator.call(context, obj[i], i, obj) === false) {
+	          return;
+	        }
+	      }
+	    }
+	    // objects
+	    else {
+	      for (i in obj) {
+	        if (obj.hasOwnProperty(i) && iterator.call(context, obj[i], i, obj) === false) {
+	          return;
+	        }
+	      }
+	    }
+	  },
+
+	  /**
+	   * find if a node is in the given parent
+	   * used for event delegation tricks
+	   * @param   {HTMLElement}   node
+	   * @param   {HTMLElement}   parent
+	   * @returns {boolean}       has_parent
+	   */
+	  hasParent: function(node, parent) {
+	    while(node) {
+	      if(node == parent) {
+	        return true;
+	      }
+	      node = node.parentNode;
+	    }
+	    return false;
+	  },
+
+
+	  /**
+	   * get the center of all the touches
+	   * @param   {Array}     touches
+	   * @returns {Object}    center
+	   */
+	  getCenter: function getCenter(touches) {
+	    var valuesX = [], valuesY = [];
+
+	    Hammer.utils.each(touches, function(touch) {
+	      // I prefer clientX because it ignore the scrolling position
+	      valuesX.push(typeof touch.clientX !== 'undefined' ? touch.clientX : touch.pageX );
+	      valuesY.push(typeof touch.clientY !== 'undefined' ? touch.clientY : touch.pageY );
+	    });
+
+	    return {
+	      pageX: ((Math.min.apply(Math, valuesX) + Math.max.apply(Math, valuesX)) / 2),
+	      pageY: ((Math.min.apply(Math, valuesY) + Math.max.apply(Math, valuesY)) / 2)
+	    };
+	  },
+
+
+	  /**
+	   * calculate the velocity between two points
+	   * @param   {Number}    delta_time
+	   * @param   {Number}    delta_x
+	   * @param   {Number}    delta_y
+	   * @returns {Object}    velocity
+	   */
+	  getVelocity: function getVelocity(delta_time, delta_x, delta_y) {
+	    return {
+	      x: Math.abs(delta_x / delta_time) || 0,
+	      y: Math.abs(delta_y / delta_time) || 0
+	    };
+	  },
+
+
+	  /**
+	   * calculate the angle between two coordinates
+	   * @param   {Touch}     touch1
+	   * @param   {Touch}     touch2
+	   * @returns {Number}    angle
+	   */
+	  getAngle: function getAngle(touch1, touch2) {
+	    var y = touch2.pageY - touch1.pageY,
+	      x = touch2.pageX - touch1.pageX;
+	    return Math.atan2(y, x) * 180 / Math.PI;
+	  },
+
+
+	  /**
+	   * angle to direction define
+	   * @param   {Touch}     touch1
+	   * @param   {Touch}     touch2
+	   * @returns {String}    direction constant, like Hammer.DIRECTION_LEFT
+	   */
+	  getDirection: function getDirection(touch1, touch2) {
+	    var x = Math.abs(touch1.pageX - touch2.pageX),
+	      y = Math.abs(touch1.pageY - touch2.pageY);
+
+	    if(x >= y) {
+	      return touch1.pageX - touch2.pageX > 0 ? Hammer.DIRECTION_LEFT : Hammer.DIRECTION_RIGHT;
+	    }
+	    else {
+	      return touch1.pageY - touch2.pageY > 0 ? Hammer.DIRECTION_UP : Hammer.DIRECTION_DOWN;
+	    }
+	  },
+
+
+	  /**
+	   * calculate the distance between two touches
+	   * @param   {Touch}     touch1
+	   * @param   {Touch}     touch2
+	   * @returns {Number}    distance
+	   */
+	  getDistance: function getDistance(touch1, touch2) {
+	    var x = touch2.pageX - touch1.pageX,
+	      y = touch2.pageY - touch1.pageY;
+	    return Math.sqrt((x * x) + (y * y));
+	  },
+
+
+	  /**
+	   * calculate the scale factor between two touchLists (fingers)
+	   * no scale is 1, and goes down to 0 when pinched together, and bigger when pinched out
+	   * @param   {Array}     start
+	   * @param   {Array}     end
+	   * @returns {Number}    scale
+	   */
+	  getScale: function getScale(start, end) {
+	    // need two fingers...
+	    if(start.length >= 2 && end.length >= 2) {
+	      return this.getDistance(end[0], end[1]) /
+	        this.getDistance(start[0], start[1]);
+	    }
+	    return 1;
+	  },
+
+
+	  /**
+	   * calculate the rotation degrees between two touchLists (fingers)
+	   * @param   {Array}     start
+	   * @param   {Array}     end
+	   * @returns {Number}    rotation
+	   */
+	  getRotation: function getRotation(start, end) {
+	    // need two fingers
+	    if(start.length >= 2 && end.length >= 2) {
+	      return this.getAngle(end[1], end[0]) -
+	        this.getAngle(start[1], start[0]);
+	    }
+	    return 0;
+	  },
+
+
+	  /**
+	   * boolean if the direction is vertical
+	   * @param    {String}    direction
+	   * @returns  {Boolean}   is_vertical
+	   */
+	  isVertical: function isVertical(direction) {
+	    return (direction == Hammer.DIRECTION_UP || direction == Hammer.DIRECTION_DOWN);
+	  },
+
+
+	  /**
+	   * stop browser default behavior with css props
+	   * @param   {HtmlElement}   element
+	   * @param   {Object}        css_props
+	   */
+	  stopDefaultBrowserBehavior: function stopDefaultBrowserBehavior(element, css_props) {
+	    if(!css_props || !element || !element.style) {
+	      return;
+	    }
+
+	    // with css properties for modern browsers
+	    Hammer.utils.each(['webkit', 'khtml', 'moz', 'Moz', 'ms', 'o', ''], function(vendor) {
+	      Hammer.utils.each(css_props, function(prop) {
+	          // vender prefix at the property
+	          if(vendor) {
+	            prop = vendor + prop.substring(0, 1).toUpperCase() + prop.substring(1);
+	          }
+	          // set the style
+	          if(prop in element.style) {
+	            element.style[prop] = prop;
+	          }
+	      });
+	    });
+
+	    // also the disable onselectstart
+	    if(css_props.userSelect == 'none') {
+	      element.onselectstart = function() {
+	        return false;
+	      };
+	    }
+
+	    // and disable ondragstart
+	    if(css_props.userDrag == 'none') {
+	      element.ondragstart = function() {
+	        return false;
+	      };
+	    }
+	  }
+	};
+
+
 	/**
 	 * create new hammer instance
 	 * all methods should return the instance itself, so it is chainable.
@@ -118,105 +350,111 @@ webpackJsonp([1],
 	 * @constructor
 	 */
 	Hammer.Instance = function(element, options) {
-	    var self = this;
-	
-	    // setup HammerJS window events and register all gestures
-	    // this also sets up the default options
-	    setup();
-	
-	    this.element = element;
-	
-	    // start/stop detection option
-	    this.enabled = true;
-	
-	    // merge options
-	    this.options = Hammer.utils.extend(
-	        Hammer.utils.extend({}, Hammer.defaults),
-	        options || {});
-	
-	    // add some css to the element to prevent the browser from doing its native behavoir
-	    if(this.options.stop_browser_behavior) {
-	        Hammer.utils.stopDefaultBrowserBehavior(this.element, this.options.stop_browser_behavior);
+	  var self = this;
+
+	  // setup HammerJS window events and register all gestures
+	  // this also sets up the default options
+	  setup();
+
+	  this.element = element;
+
+	  // start/stop detection option
+	  this.enabled = true;
+
+	  // merge options
+	  this.options = Hammer.utils.extend(
+	    Hammer.utils.extend({}, Hammer.defaults),
+	    options || {});
+
+	  // add some css to the element to prevent the browser from doing its native behavoir
+	  if(this.options.stop_browser_behavior) {
+	    Hammer.utils.stopDefaultBrowserBehavior(this.element, this.options.stop_browser_behavior);
+	  }
+
+	  // start detection on touchstart
+	  Hammer.event.onTouch(element, Hammer.EVENT_START, function(ev) {
+	    if(self.enabled) {
+	      Hammer.detection.startDetect(self, ev);
 	    }
-	
-	    // start detection on touchstart
-	    Hammer.event.onTouch(element, Hammer.EVENT_START, function(ev) {
-	        if(self.enabled) {
-	            Hammer.detection.startDetect(self, ev);
-	        }
-	    });
-	
-	    // return instance
-	    return this;
+	  });
+
+	  // return instance
+	  return this;
 	};
-	
-	
+
+
 	Hammer.Instance.prototype = {
-	    /**
-	     * bind events to the instance
-	     * @param   {String}      gesture
-	     * @param   {Function}    handler
-	     * @returns {Hammer.Instance}
-	     */
-	    on: function onEvent(gesture, handler){
-	        var gestures = gesture.split(' ');
-	        for(var t=0; t<gestures.length; t++) {
-	            this.element.addEventListener(gestures[t], handler, false);
-	        }
-	        return this;
-	    },
-	
-	
-	    /**
-	     * unbind events to the instance
-	     * @param   {String}      gesture
-	     * @param   {Function}    handler
-	     * @returns {Hammer.Instance}
-	     */
-	    off: function offEvent(gesture, handler){
-	        var gestures = gesture.split(' ');
-	        for(var t=0; t<gestures.length; t++) {
-	            this.element.removeEventListener(gestures[t], handler, false);
-	        }
-	        return this;
-	    },
-	
-	
-	    /**
-	     * trigger gesture event
-	     * @param   {String}      gesture
-	     * @param   {Object}      eventData
-	     * @returns {Hammer.Instance}
-	     */
-	    trigger: function triggerEvent(gesture, eventData){
-	        // create DOM event
-	        var event = Hammer.DOCUMENT.createEvent('Event');
-			event.initEvent(gesture, true, true);
-			event.gesture = eventData;
-	
-	        // trigger on the target if it is in the instance element,
-	        // this is for event delegation tricks
-	        var element = this.element;
-	        if(Hammer.utils.hasParent(eventData.target, element)) {
-	            element = eventData.target;
-	        }
-	
-	        element.dispatchEvent(event);
-	        return this;
-	    },
-	
-	
-	    /**
-	     * enable of disable hammer.js detection
-	     * @param   {Boolean}   state
-	     * @returns {Hammer.Instance}
-	     */
-	    enable: function enable(state) {
-	        this.enabled = state;
-	        return this;
+	  /**
+	   * bind events to the instance
+	   * @param   {String}      gesture
+	   * @param   {Function}    handler
+	   * @returns {Hammer.Instance}
+	   */
+	  on: function onEvent(gesture, handler) {
+	    var gestures = gesture.split(' ');
+	    Hammer.utils.each(gestures, function(gesture) {
+	      this.element.addEventListener(gesture, handler, false);
+	    }, this);
+	    return this;
+	  },
+
+
+	  /**
+	   * unbind events to the instance
+	   * @param   {String}      gesture
+	   * @param   {Function}    handler
+	   * @returns {Hammer.Instance}
+	   */
+	  off: function offEvent(gesture, handler) {
+	    var gestures = gesture.split(' ');
+	    Hammer.utils.each(gestures, function(gesture) {
+	      this.element.removeEventListener(gesture, handler, false);
+	    }, this);
+	    return this;
+	  },
+
+
+	  /**
+	   * trigger gesture event
+	   * @param   {String}      gesture
+	   * @param   {Object}      [eventData]
+	   * @returns {Hammer.Instance}
+	   */
+	  trigger: function triggerEvent(gesture, eventData) {
+	    // optional
+	    if(!eventData) {
+	      eventData = {};
 	    }
+
+	    // create DOM event
+	    var event = Hammer.DOCUMENT.createEvent('Event');
+	    event.initEvent(gesture, true, true);
+	    event.gesture = eventData;
+
+	    // trigger on the target if it is in the instance element,
+	    // this is for event delegation tricks
+	    var element = this.element;
+	    if(Hammer.utils.hasParent(eventData.target, element)) {
+	      element = eventData.target;
+	    }
+
+	    element.dispatchEvent(event);
+	    return this;
+	  },
+
+
+	  /**
+	   * enable of disable hammer.js detection
+	   * @param   {Boolean}   state
+	   * @returns {Hammer.Instance}
+	   */
+	  enable: function enable(state) {
+	    this.enabled = state;
+	    return this;
+	  }
 	};
-	
+
+
 	/**
 	 * this holds the last move event,
 	 * used to fix empty touchend issue
@@ -224,945 +462,517 @@ webpackJsonp([1],
 	 * @type {Object}
 	 */
 	var last_move_event = null;
-	
-	
+
+
 	/**
 	 * when the mouse is hold down, this is true
 	 * @type {Boolean}
 	 */
 	var enable_detect = false;
-	
-	
+
+
 	/**
 	 * when touch events have been fired, this is true
 	 * @type {Boolean}
 	 */
 	var touch_triggered = false;
-	
-	
+
+
 	Hammer.event = {
-	    /**
-	     * simple addEventListener
-	     * @param   {HTMLElement}   element
-	     * @param   {String}        type
-	     * @param   {Function}      handler
-	     */
-	    bindDom: function(element, type, handler) {
-	        var types = type.split(' ');
-	        for(var t=0; t<types.length; t++) {
-	            element.addEventListener(types[t], handler, false);
+	  /**
+	   * simple addEventListener
+	   * @param   {HTMLElement}   element
+	   * @param   {String}        type
+	   * @param   {Function}      handler
+	   */
+	  bindDom: function(element, type, handler) {
+	    var types = type.split(' ');
+	    Hammer.utils.each(types, function(type){
+	      element.addEventListener(type, handler, false);
+	    });
+	  },
+
+
+	  /**
+	   * touch events with mouse fallback
+	   * @param   {HTMLElement}   element
+	   * @param   {String}        eventType        like Hammer.EVENT_MOVE
+	   * @param   {Function}      handler
+	   */
+	  onTouch: function onTouch(element, eventType, handler) {
+	    var self = this;
+
+	    this.bindDom(element, Hammer.EVENT_TYPES[eventType], function bindDomOnTouch(ev) {
+	      var sourceEventType = ev.type.toLowerCase();
+
+	      // onmouseup, but when touchend has been fired we do nothing.
+	      // this is for touchdevices which also fire a mouseup on touchend
+	      if(sourceEventType.match(/mouse/) && touch_triggered) {
+	        return;
+	      }
+
+	      // mousebutton must be down or a touch event
+	      else if(sourceEventType.match(/touch/) ||   // touch events are always on screen
+	        sourceEventType.match(/pointerdown/) || // pointerevents touch
+	        (sourceEventType.match(/mouse/) && ev.which === 1)   // mouse is pressed
+	        ) {
+	        enable_detect = true;
+	      }
+
+	      // mouse isn't pressed
+	      else if(sourceEventType.match(/mouse/) && !ev.which) {
+	        enable_detect = false;
+	      }
+
+
+	      // we are in a touch event, set the touch triggered bool to true,
+	      // this for the conflicts that may occur on ios and android
+	      if(sourceEventType.match(/touch|pointer/)) {
+	        touch_triggered = true;
+	      }
+
+	      // count the total touches on the screen
+	      var count_touches = 0;
+
+	      // when touch has been triggered in this detection session
+	      // and we are now handling a mouse event, we stop that to prevent conflicts
+	      if(enable_detect) {
+	        // update pointerevent
+	        if(Hammer.HAS_POINTEREVENTS && eventType != Hammer.EVENT_END) {
+	          count_touches = Hammer.PointerEvent.updatePointer(eventType, ev);
 	        }
-	    },
-	
-	
-	    /**
-	     * touch events with mouse fallback
-	     * @param   {HTMLElement}   element
-	     * @param   {String}        eventType        like Hammer.EVENT_MOVE
-	     * @param   {Function}      handler
-	     */
-	    onTouch: function onTouch(element, eventType, handler) {
-			var self = this;
-	
-	        this.bindDom(element, Hammer.EVENT_TYPES[eventType], function bindDomOnTouch(ev) {
-	            var sourceEventType = ev.type.toLowerCase();
-	
-	            // onmouseup, but when touchend has been fired we do nothing.
-	            // this is for touchdevices which also fire a mouseup on touchend
-	            if(sourceEventType.match(/mouse/) && touch_triggered) {
-	                return;
-	            }
-	
-	            // mousebutton must be down or a touch event
-	            else if( sourceEventType.match(/touch/) ||   // touch events are always on screen
-	                sourceEventType.match(/pointerdown/) || // pointerevents touch
-	                (sourceEventType.match(/mouse/) && ev.which === 1)   // mouse is pressed
-	            ){
-	                enable_detect = true;
-	            }
-	
-	            // we are in a touch event, set the touch triggered bool to true,
-	            // this for the conflicts that may occur on ios and android
-	            if(sourceEventType.match(/touch|pointer/)) {
-	                touch_triggered = true;
-	            }
-	
-	            // count the total touches on the screen
-	            var count_touches = 0;
-	
-	            // when touch has been triggered in this detection session
-	            // and we are now handling a mouse event, we stop that to prevent conflicts
-	            if(enable_detect) {
-	                // update pointerevent
-	                if(Hammer.HAS_POINTEREVENTS && eventType != Hammer.EVENT_END) {
-	                    count_touches = Hammer.PointerEvent.updatePointer(eventType, ev);
-	                }
-	                // touch
-	                else if(sourceEventType.match(/touch/)) {
-	                    count_touches = ev.touches.length;
-	                }
-	                // mouse
-	                else if(!touch_triggered) {
-	                    count_touches = sourceEventType.match(/up/) ? 0 : 1;
-	                }
-	
-	                // if we are in a end event, but when we remove one touch and
-	                // we still have enough, set eventType to move
-	                if(count_touches > 0 && eventType == Hammer.EVENT_END) {
-	                    eventType = Hammer.EVENT_MOVE;
-	                }
-	                // no touches, force the end event
-	                else if(!count_touches) {
-	                    eventType = Hammer.EVENT_END;
-	                }
-	
-	                // because touchend has no touches, and we often want to use these in our gestures,
-	                // we send the last move event as our eventData in touchend
-	                if(!count_touches && last_move_event !== null) {
-	                    ev = last_move_event;
-	                }
-	                // store the last move event
-	                else {
-	                    last_move_event = ev;
-	                }
-	
-	                // trigger the handler
-	                handler.call(Hammer.detection, self.collectEventData(element, eventType, ev));
-	
-	                // remove pointerevent from list
-	                if(Hammer.HAS_POINTEREVENTS && eventType == Hammer.EVENT_END) {
-	                    count_touches = Hammer.PointerEvent.updatePointer(eventType, ev);
-	                }
-	            }
-	
-	            //debug(sourceEventType +" "+ eventType);
-	
-	            // on the end we reset everything
-	            if(!count_touches) {
-	                last_move_event = null;
-	                enable_detect = false;
-	                touch_triggered = false;
-	                Hammer.PointerEvent.reset();
-	            }
-	        });
-	    },
-	
-	
-	    /**
-	     * we have different events for each device/browser
-	     * determine what we need and set them in the Hammer.EVENT_TYPES constant
-	     */
-	    determineEventTypes: function determineEventTypes() {
-	        // determine the eventtype we want to set
-	        var types;
-	
-	        // pointerEvents magic
-	        if(Hammer.HAS_POINTEREVENTS) {
-	            types = Hammer.PointerEvent.getEvents();
+	        // touch
+	        else if(sourceEventType.match(/touch/)) {
+	          count_touches = ev.touches.length;
 	        }
-	        // on Android, iOS, blackberry, windows mobile we dont want any mouseevents
-	        else if(Hammer.NO_MOUSEEVENTS) {
-	            types = [
-	                'touchstart',
-	                'touchmove',
-	                'touchend touchcancel'];
+	        // mouse
+	        else if(!touch_triggered) {
+	          count_touches = sourceEventType.match(/up/) ? 0 : 1;
 	        }
-	        // for non pointer events browsers and mixed browsers,
-	        // like chrome on windows8 touch laptop
-	        else {
-	            types = [
-	                'touchstart mousedown',
-	                'touchmove mousemove',
-	                'touchend touchcancel mouseup'];
+
+	        // if we are in a end event, but when we remove one touch and
+	        // we still have enough, set eventType to move
+	        if(count_touches > 0 && eventType == Hammer.EVENT_END) {
+	          eventType = Hammer.EVENT_MOVE;
 	        }
-	
-	        Hammer.EVENT_TYPES[Hammer.EVENT_START]  = types[0];
-	        Hammer.EVENT_TYPES[Hammer.EVENT_MOVE]   = types[1];
-	        Hammer.EVENT_TYPES[Hammer.EVENT_END]    = types[2];
-	    },
-	
-	
-	    /**
-	     * create touchlist depending on the event
-	     * @param   {Object}    ev
-	     * @param   {String}    eventType   used by the fakemultitouch plugin
-	     */
-	    getTouchList: function getTouchList(ev/*, eventType*/) {
-	        // get the fake pointerEvent touchlist
-	        if(Hammer.HAS_POINTEREVENTS) {
-	            return Hammer.PointerEvent.getTouchList();
+	        // no touches, force the end event
+	        else if(!count_touches) {
+	          eventType = Hammer.EVENT_END;
 	        }
-	        // get the touchlist
-	        else if(ev.touches) {
-	            return ev.touches;
+
+	        // store the last move event
+	        if(count_touches || last_move_event === null) {
+	          last_move_event = ev;
 	        }
-	        // make fake touchlist from mouse position
-	        else {
-	            return [{
-	                identifier: 1,
-	                pageX: ev.pageX,
-	                pageY: ev.pageY,
-	                target: ev.target
-	            }];
+
+	        // trigger the handler
+	        handler.call(Hammer.detection, self.collectEventData(element, eventType, self.getTouchList(last_move_event, eventType), ev));
+
+	        // remove pointerevent from list
+	        if(Hammer.HAS_POINTEREVENTS && eventType == Hammer.EVENT_END) {
+	          count_touches = Hammer.PointerEvent.updatePointer(eventType, ev);
 	        }
-	    },
-	
-	
-	    /**
-	     * collect event data for Hammer js
-	     * @param   {HTMLElement}   element
-	     * @param   {String}        eventType        like Hammer.EVENT_MOVE
-	     * @param   {Object}        eventData
-	     */
-	    collectEventData: function collectEventData(element, eventType, ev) {
-	        var touches = this.getTouchList(ev, eventType);
-	
-	        // find out pointerType
-	        var pointerType = Hammer.POINTER_TOUCH;
-	        if(ev.type.match(/mouse/) || Hammer.PointerEvent.matchType(Hammer.POINTER_MOUSE, ev)) {
-	            pointerType = Hammer.POINTER_MOUSE;
-	        }
-	
-	        return {
-	            center      : Hammer.utils.getCenter(touches),
-	            timeStamp   : new Date().getTime(),
-	            target      : ev.target,
-	            touches     : touches,
-	            eventType   : eventType,
-	            pointerType : pointerType,
-	            srcEvent    : ev,
-	
-	            /**
-	             * prevent the browser default actions
-	             * mostly used to disable scrolling of the browser
-	             */
-	            preventDefault: function() {
-	                if(this.srcEvent.preventManipulation) {
-	                    this.srcEvent.preventManipulation();
-	                }
-	
-	                if(this.srcEvent.preventDefault) {
-	                    this.srcEvent.preventDefault();
-	                }
-	            },
-	
-	            /**
-	             * stop bubbling the event up to its parents
-	             */
-	            stopPropagation: function() {
-	                this.srcEvent.stopPropagation();
-	            },
-	
-	            /**
-	             * immediately stop gesture detection
-	             * might be useful after a swipe was detected
-	             * @return {*}
-	             */
-	            stopDetect: function() {
-	                return Hammer.detection.stopDetect();
-	            }
-	        };
+	      }
+
+	      // on the end we reset everything
+	      if(!count_touches) {
+	        last_move_event = null;
+	        enable_detect = false;
+	        touch_triggered = false;
+	        Hammer.PointerEvent.reset();
+	      }
+	    });
+	  },
+
+
+	  /**
+	   * we have different events for each device/browser
+	   * determine what we need and set them in the Hammer.EVENT_TYPES constant
+	   */
+	  determineEventTypes: function determineEventTypes() {
+	    // determine the eventtype we want to set
+	    var types;
+
+	    // pointerEvents magic
+	    if(Hammer.HAS_POINTEREVENTS) {
+	      types = Hammer.PointerEvent.getEvents();
 	    }
+	    // on Android, iOS, blackberry, windows mobile we dont want any mouseevents
+	    else if(Hammer.NO_MOUSEEVENTS) {
+	      types = [
+	        'touchstart',
+	        'touchmove',
+	        'touchend touchcancel'];
+	    }
+	    // for non pointer events browsers and mixed browsers,
+	    // like chrome on windows8 touch laptop
+	    else {
+	      types = [
+	        'touchstart mousedown',
+	        'touchmove mousemove',
+	        'touchend touchcancel mouseup'];
+	    }
+
+	    Hammer.EVENT_TYPES[Hammer.EVENT_START] = types[0];
+	    Hammer.EVENT_TYPES[Hammer.EVENT_MOVE] = types[1];
+	    Hammer.EVENT_TYPES[Hammer.EVENT_END] = types[2];
+	  },
+
+
+	  /**
+	   * create touchlist depending on the event
+	   * @param   {Object}    ev
+	   * @param   {String}    eventType   used by the fakemultitouch plugin
+	   */
+	  getTouchList: function getTouchList(ev/*, eventType*/) {
+	    // get the fake pointerEvent touchlist
+	    if(Hammer.HAS_POINTEREVENTS) {
+	      return Hammer.PointerEvent.getTouchList();
+	    }
+	    // get the touchlist
+	    else if(ev.touches) {
+	      return ev.touches;
+	    }
+	    // make fake touchlist from mouse position
+	    else {
+	      ev.identifier = 1;
+	      return [ev];
+	    }
+	  },
+
+
+	  /**
+	   * collect event data for Hammer js
+	   * @param   {HTMLElement}   element
+	   * @param   {String}        eventType        like Hammer.EVENT_MOVE
+	   * @param   {Object}        eventData
+	   */
+	  collectEventData: function collectEventData(element, eventType, touches, ev) {
+	    // find out pointerType
+	    var pointerType = Hammer.POINTER_TOUCH;
+	    if(ev.type.match(/mouse/) || Hammer.PointerEvent.matchType(Hammer.POINTER_MOUSE, ev)) {
+	      pointerType = Hammer.POINTER_MOUSE;
+	    }
+
+	    return {
+	      center     : Hammer.utils.getCenter(touches),
+	      timeStamp  : new Date().getTime(),
+	      target     : ev.target,
+	      touches    : touches,
+	      eventType  : eventType,
+	      pointerType: pointerType,
+	      srcEvent   : ev,
+
+	      /**
+	       * prevent the browser default actions
+	       * mostly used to disable scrolling of the browser
+	       */
+	      preventDefault: function() {
+	        if(this.srcEvent.preventManipulation) {
+	          this.srcEvent.preventManipulation();
+	        }
+
+	        if(this.srcEvent.preventDefault) {
+	          this.srcEvent.preventDefault();
+	        }
+	      },
+
+	      /**
+	       * stop bubbling the event up to its parents
+	       */
+	      stopPropagation: function() {
+	        this.srcEvent.stopPropagation();
+	      },
+
+	      /**
+	       * immediately stop gesture detection
+	       * might be useful after a swipe was detected
+	       * @return {*}
+	       */
+	      stopDetect: function() {
+	        return Hammer.detection.stopDetect();
+	      }
+	    };
+	  }
 	};
-	
+
 	Hammer.PointerEvent = {
-	    /**
-	     * holds all pointers
-	     * @type {Object}
-	     */
-	    pointers: {},
-	
-	    /**
-	     * get a list of pointers
-	     * @returns {Array}     touchlist
-	     */
-	    getTouchList: function() {
-	        var self = this;
-	        var touchlist = [];
-	
-	        // we can use forEach since pointerEvents only is in IE10
-	        Object.keys(self.pointers).sort().forEach(function(id) {
-	            touchlist.push(self.pointers[id]);
-	        });
-	        return touchlist;
-	    },
-	
-	    /**
-	     * update the position of a pointer
-	     * @param   {String}   type             Hammer.EVENT_END
-	     * @param   {Object}   pointerEvent
-	     */
-	    updatePointer: function(type, pointerEvent) {
-	        if(type == Hammer.EVENT_END) {
-	            this.pointers = {};
-	        }
-	        else {
-	            pointerEvent.identifier = pointerEvent.pointerId;
-	            this.pointers[pointerEvent.pointerId] = pointerEvent;
-	        }
-	
-	        return Object.keys(this.pointers).length;
-	    },
-	
-	    /**
-	     * check if ev matches pointertype
-	     * @param   {String}        pointerType     Hammer.POINTER_MOUSE
-	     * @param   {PointerEvent}  ev
-	     */
-	    matchType: function(pointerType, ev) {
-	        if(!ev.pointerType) {
-	            return false;
-	        }
-	
-	        var types = {};
-	        types[Hammer.POINTER_MOUSE] = (ev.pointerType == ev.MSPOINTER_TYPE_MOUSE || ev.pointerType == Hammer.POINTER_MOUSE);
-	        types[Hammer.POINTER_TOUCH] = (ev.pointerType == ev.MSPOINTER_TYPE_TOUCH || ev.pointerType == Hammer.POINTER_TOUCH);
-	        types[Hammer.POINTER_PEN] = (ev.pointerType == ev.MSPOINTER_TYPE_PEN || ev.pointerType == Hammer.POINTER_PEN);
-	        return types[pointerType];
-	    },
-	
-	
-	    /**
-	     * get events
-	     */
-	    getEvents: function() {
-	        return [
-	            'pointerdown MSPointerDown',
-	            'pointermove MSPointerMove',
-	            'pointerup pointercancel MSPointerUp MSPointerCancel'
-	        ];
-	    },
-	
-	    /**
-	     * reset the list
-	     */
-	    reset: function() {
-	        this.pointers = {};
+	  /**
+	   * holds all pointers
+	   * @type {Object}
+	   */
+	  pointers: {},
+
+	  /**
+	   * get a list of pointers
+	   * @returns {Array}     touchlist
+	   */
+	  getTouchList: function() {
+	    var self = this;
+	    var touchlist = [];
+
+	    // we can use forEach since pointerEvents only is in IE10
+	    Hammer.utils.each(self.pointers, function(pointer){
+	      touchlist.push(pointer);
+	    });
+	    
+	    return touchlist;
+	  },
+
+	  /**
+	   * update the position of a pointer
+	   * @param   {String}   type             Hammer.EVENT_END
+	   * @param   {Object}   pointerEvent
+	   */
+	  updatePointer: function(type, pointerEvent) {
+	    if(type == Hammer.EVENT_END) {
+	      this.pointers = {};
 	    }
-	};
-	
-	
-	Hammer.utils = {
-	    /**
-	     * extend method,
-	     * also used for cloning when dest is an empty object
-	     * @param   {Object}    dest
-	     * @param   {Object}    src
-		 * @parm	{Boolean}	merge		do a merge
-	     * @returns {Object}    dest
-	     */
-	    extend: function extend(dest, src, merge) {
-	        for (var key in src) {
-				if(dest[key] !== undefined && merge) {
-					continue;
-				}
-	            dest[key] = src[key];
-	        }
-	        return dest;
-	    },
-	
-	
-	    /**
-	     * find if a node is in the given parent
-	     * used for event delegation tricks
-	     * @param   {HTMLElement}   node
-	     * @param   {HTMLElement}   parent
-	     * @returns {boolean}       has_parent
-	     */
-	    hasParent: function(node, parent) {
-	        while(node){
-	            if(node == parent) {
-	                return true;
-	            }
-	            node = node.parentNode;
-	        }
-	        return false;
-	    },
-	
-	
-	    /**
-	     * get the center of all the touches
-	     * @param   {Array}     touches
-	     * @returns {Object}    center
-	     */
-	    getCenter: function getCenter(touches) {
-	        var valuesX = [], valuesY = [];
-	
-	        for(var t= 0,len=touches.length; t<len; t++) {
-	            valuesX.push(touches[t].pageX);
-	            valuesY.push(touches[t].pageY);
-	        }
-	
-	        return {
-	            pageX: ((Math.min.apply(Math, valuesX) + Math.max.apply(Math, valuesX)) / 2),
-	            pageY: ((Math.min.apply(Math, valuesY) + Math.max.apply(Math, valuesY)) / 2)
-	        };
-	    },
-	
-	
-	    /**
-	     * calculate the velocity between two points
-	     * @param   {Number}    delta_time
-	     * @param   {Number}    delta_x
-	     * @param   {Number}    delta_y
-	     * @returns {Object}    velocity
-	     */
-	    getVelocity: function getVelocity(delta_time, delta_x, delta_y) {
-	        return {
-	            x: Math.abs(delta_x / delta_time) || 0,
-	            y: Math.abs(delta_y / delta_time) || 0
-	        };
-	    },
-	
-	
-	    /**
-	     * calculate the angle between two coordinates
-	     * @param   {Touch}     touch1
-	     * @param   {Touch}     touch2
-	     * @returns {Number}    angle
-	     */
-	    getAngle: function getAngle(touch1, touch2) {
-	        var y = touch2.pageY - touch1.pageY,
-	            x = touch2.pageX - touch1.pageX;
-	        return Math.atan2(y, x) * 180 / Math.PI;
-	    },
-	
-	
-	    /**
-	     * angle to direction define
-	     * @param   {Touch}     touch1
-	     * @param   {Touch}     touch2
-	     * @returns {String}    direction constant, like Hammer.DIRECTION_LEFT
-	     */
-	    getDirection: function getDirection(touch1, touch2) {
-	        var x = Math.abs(touch1.pageX - touch2.pageX),
-	            y = Math.abs(touch1.pageY - touch2.pageY);
-	
-	        if(x >= y) {
-	            return touch1.pageX - touch2.pageX > 0 ? Hammer.DIRECTION_LEFT : Hammer.DIRECTION_RIGHT;
-	        }
-	        else {
-	            return touch1.pageY - touch2.pageY > 0 ? Hammer.DIRECTION_UP : Hammer.DIRECTION_DOWN;
-	        }
-	    },
-	
-	
-	    /**
-	     * calculate the distance between two touches
-	     * @param   {Touch}     touch1
-	     * @param   {Touch}     touch2
-	     * @returns {Number}    distance
-	     */
-	    getDistance: function getDistance(touch1, touch2) {
-	        var x = touch2.pageX - touch1.pageX,
-	            y = touch2.pageY - touch1.pageY;
-	        return Math.sqrt((x*x) + (y*y));
-	    },
-	
-	
-	    /**
-	     * calculate the scale factor between two touchLists (fingers)
-	     * no scale is 1, and goes down to 0 when pinched together, and bigger when pinched out
-	     * @param   {Array}     start
-	     * @param   {Array}     end
-	     * @returns {Number}    scale
-	     */
-	    getScale: function getScale(start, end) {
-	        // need two fingers...
-	        if(start.length >= 2 && end.length >= 2) {
-	            return this.getDistance(end[0], end[1]) /
-	                this.getDistance(start[0], start[1]);
-	        }
-	        return 1;
-	    },
-	
-	
-	    /**
-	     * calculate the rotation degrees between two touchLists (fingers)
-	     * @param   {Array}     start
-	     * @param   {Array}     end
-	     * @returns {Number}    rotation
-	     */
-	    getRotation: function getRotation(start, end) {
-	        // need two fingers
-	        if(start.length >= 2 && end.length >= 2) {
-	            return this.getAngle(end[1], end[0]) -
-	                this.getAngle(start[1], start[0]);
-	        }
-	        return 0;
-	    },
-	
-	
-	    /**
-	     * boolean if the direction is vertical
-	     * @param    {String}    direction
-	     * @returns  {Boolean}   is_vertical
-	     */
-	    isVertical: function isVertical(direction) {
-	        return (direction == Hammer.DIRECTION_UP || direction == Hammer.DIRECTION_DOWN);
-	    },
-	
-	
-	    /**
-	     * stop browser default behavior with css props
-	     * @param   {HtmlElement}   element
-	     * @param   {Object}        css_props
-	     */
-	    stopDefaultBrowserBehavior: function stopDefaultBrowserBehavior(element, css_props) {
-	        var prop,
-	            vendors = ['webkit','khtml','moz','ms','o',''];
-	
-	        if(!css_props || !element.style) {
-	            return;
-	        }
-	
-	        // with css properties for modern browsers
-	        for(var i = 0; i < vendors.length; i++) {
-	            for(var p in css_props) {
-	                if(css_props.hasOwnProperty(p)) {
-	                    prop = p;
-	
-	                    // vender prefix at the property
-	                    if(vendors[i]) {
-	                        prop = vendors[i] + prop.substring(0, 1).toUpperCase() + prop.substring(1);
-	                    }
-	
-	                    // set the style
-	                    element.style[prop] = css_props[p];
-	                }
-	            }
-	        }
-	
-	        // also the disable onselectstart
-	        if(css_props.userSelect == 'none') {
-	            element.onselectstart = function() {
-	                return false;
-	            };
-	        }
+	    else {
+	      pointerEvent.identifier = pointerEvent.pointerId;
+	      this.pointers[pointerEvent.pointerId] = pointerEvent;
 	    }
+
+	    return Object.keys(this.pointers).length;
+	  },
+
+	  /**
+	   * check if ev matches pointertype
+	   * @param   {String}        pointerType     Hammer.POINTER_MOUSE
+	   * @param   {PointerEvent}  ev
+	   */
+	  matchType: function(pointerType, ev) {
+	    if(!ev.pointerType) {
+	      return false;
+	    }
+
+	    var pt = ev.pointerType,
+	      types = {};
+	    types[Hammer.POINTER_MOUSE] = (pt === ev.MSPOINTER_TYPE_MOUSE || pt === Hammer.POINTER_MOUSE);
+	    types[Hammer.POINTER_TOUCH] = (pt === ev.MSPOINTER_TYPE_TOUCH || pt === Hammer.POINTER_TOUCH);
+	    types[Hammer.POINTER_PEN] = (pt === ev.MSPOINTER_TYPE_PEN || pt === Hammer.POINTER_PEN);
+	    return types[pointerType];
+	  },
+
+
+	  /**
+	   * get events
+	   */
+	  getEvents: function() {
+	    return [
+	      'pointerdown MSPointerDown',
+	      'pointermove MSPointerMove',
+	      'pointerup pointercancel MSPointerUp MSPointerCancel'
+	    ];
+	  },
+
+	  /**
+	   * reset the list
+	   */
+	  reset: function() {
+	    this.pointers = {};
+	  }
 	};
-	
+
+
 	Hammer.detection = {
-	    // contains all registred Hammer.gestures in the correct order
-	    gestures: [],
-	
-	    // data of the current Hammer.gesture detection session
-	    current: null,
-	
-	    // the previous Hammer.gesture session data
-	    // is a full clone of the previous gesture.current object
-	    previous: null,
-	
-	    // when this becomes true, no gestures are fired
-	    stopped: false,
-	
-	
-	    /**
-	     * start Hammer.gesture detection
-	     * @param   {Hammer.Instance}   inst
-	     * @param   {Object}            eventData
-	     */
-	    startDetect: function startDetect(inst, eventData) {
-	        // already busy with a Hammer.gesture detection on an element
-	        if(this.current) {
-	            return;
-	        }
-	
-	        this.stopped = false;
-	
-	        this.current = {
-	            inst        : inst, // reference to HammerInstance we're working for
-	            startEvent  : Hammer.utils.extend({}, eventData), // start eventData for distances, timing etc
-	            lastEvent   : false, // last eventData
-	            name        : '' // current gesture we're in/detected, can be 'tap', 'hold' etc
-	        };
-	
-	        this.detect(eventData);
-	    },
-	
-	
-	    /**
-	     * Hammer.gesture detection
-	     * @param   {Object}    eventData
-	     * @param   {Object}    eventData
-	     */
-	    detect: function detect(eventData) {
-	        if(!this.current || this.stopped) {
-	            return;
-	        }
-	
-	        // extend event data with calculations about scale, distance etc
-	        eventData = this.extendEventData(eventData);
-	
-	        // instance options
-	        var inst_options = this.current.inst.options;
-	
-	        // call Hammer.gesture handlers
-	        for(var g=0,len=this.gestures.length; g<len; g++) {
-	            var gesture = this.gestures[g];
-	
-	            // only when the instance options have enabled this gesture
-	            if(!this.stopped && inst_options[gesture.name] !== false) {
-	                // if a handler returns false, we stop with the detection
-	                if(gesture.handler.call(gesture, eventData, this.current.inst) === false) {
-	                    this.stopDetect();
-	                    break;
-	                }
-	            }
-	        }
-	
-	        // store as previous event event
-	        if(this.current) {
-	            this.current.lastEvent = eventData;
-	        }
-	
-	        // endevent, but not the last touch, so dont stop
-	        if(eventData.eventType == Hammer.EVENT_END && !eventData.touches.length-1) {
-	            this.stopDetect();
-	        }
-	
-	        return eventData;
-	    },
-	
-	
-	    /**
-	     * clear the Hammer.gesture vars
-	     * this is called on endDetect, but can also be used when a final Hammer.gesture has been detected
-	     * to stop other Hammer.gestures from being fired
-	     */
-	    stopDetect: function stopDetect() {
-	        // clone current data to the store as the previous gesture
-	        // used for the double tap gesture, since this is an other gesture detect session
-	        this.previous = Hammer.utils.extend({}, this.current);
-	
-	        // reset the current
-	        this.current = null;
-	
-	        // stopped!
-	        this.stopped = true;
-	    },
-	
-	
-	    /**
-	     * extend eventData for Hammer.gestures
-	     * @param   {Object}   ev
-	     * @returns {Object}   ev
-	     */
-	    extendEventData: function extendEventData(ev) {
-	        var startEv = this.current.startEvent;
-	
-	        // if the touches change, set the new touches over the startEvent touches
-	        // this because touchevents don't have all the touches on touchstart, or the
-	        // user must place his fingers at the EXACT same time on the screen, which is not realistic
-	        // but, sometimes it happens that both fingers are touching at the EXACT same time
-	        if(startEv && (ev.touches.length != startEv.touches.length || ev.touches === startEv.touches)) {
-	            // extend 1 level deep to get the touchlist with the touch objects
-	            startEv.touches = [];
-	            for(var i=0,len=ev.touches.length; i<len; i++) {
-	                startEv.touches.push(Hammer.utils.extend({}, ev.touches[i]));
-	            }
-	        }
-	
-	        var delta_time = ev.timeStamp - startEv.timeStamp,
-	            delta_x = ev.center.pageX - startEv.center.pageX,
-	            delta_y = ev.center.pageY - startEv.center.pageY,
-	            velocity = Hammer.utils.getVelocity(delta_time, delta_x, delta_y);
-	
-	        Hammer.utils.extend(ev, {
-	            deltaTime   : delta_time,
-	
-	            deltaX      : delta_x,
-	            deltaY      : delta_y,
-	
-	            velocityX   : velocity.x,
-	            velocityY   : velocity.y,
-	
-	            distance    : Hammer.utils.getDistance(startEv.center, ev.center),
-	            angle       : Hammer.utils.getAngle(startEv.center, ev.center),
-	            direction   : Hammer.utils.getDirection(startEv.center, ev.center),
-	
-	            scale       : Hammer.utils.getScale(startEv.touches, ev.touches),
-	            rotation    : Hammer.utils.getRotation(startEv.touches, ev.touches),
-	
-	            startEvent  : startEv
-	        });
-	
-	        return ev;
-	    },
-	
-	
-	    /**
-	     * register new gesture
-	     * @param   {Object}    gesture object, see gestures.js for documentation
-	     * @returns {Array}     gestures
-	     */
-	    register: function register(gesture) {
-	        // add an enable gesture options if there is no given
-	        var options = gesture.defaults || {};
-	        if(options[gesture.name] === undefined) {
-	            options[gesture.name] = true;
-	        }
-	
-	        // extend Hammer default options with the Hammer.gesture options
-	        Hammer.utils.extend(Hammer.defaults, options, true);
-	
-	        // set its index
-	        gesture.index = gesture.index || 1000;
-	
-	        // add Hammer.gesture to the list
-	        this.gestures.push(gesture);
-	
-	        // sort the list by index
-	        this.gestures.sort(function(a, b) {
-	            if (a.index < b.index) {
-	                return -1;
-	            }
-	            if (a.index > b.index) {
-	                return 1;
-	            }
-	            return 0;
-	        });
-	
-	        return this.gestures;
+	  // contains all registred Hammer.gestures in the correct order
+	  gestures: [],
+
+	  // data of the current Hammer.gesture detection session
+	  current : null,
+
+	  // the previous Hammer.gesture session data
+	  // is a full clone of the previous gesture.current object
+	  previous: null,
+
+	  // when this becomes true, no gestures are fired
+	  stopped : false,
+
+
+	  /**
+	   * start Hammer.gesture detection
+	   * @param   {Hammer.Instance}   inst
+	   * @param   {Object}            eventData
+	   */
+	  startDetect: function startDetect(inst, eventData) {
+	    // already busy with a Hammer.gesture detection on an element
+	    if(this.current) {
+	      return;
 	    }
-	};
-	
-	
-	Hammer.gestures = Hammer.gestures || {};
-	
-	/**
-	 * Custom gestures
-	 * ==============================
-	 *
-	 * Gesture object
-	 * --------------------
-	 * The object structure of a gesture:
-	 *
-	 * { name: 'mygesture',
-	 *   index: 1337,
-	 *   defaults: {
-	 *     mygesture_option: true
-	 *   }
-	 *   handler: function(type, ev, inst) {
-	 *     // trigger gesture event
-	 *     inst.trigger(this.name, ev);
-	 *   }
-	 * }
-	
-	 * @param   {String}    name
-	 * this should be the name of the gesture, lowercase
-	 * it is also being used to disable/enable the gesture per instance config.
-	 *
-	 * @param   {Number}    [index=1000]
-	 * the index of the gesture, where it is going to be in the stack of gestures detection
-	 * like when you build an gesture that depends on the drag gesture, it is a good
-	 * idea to place it after the index of the drag gesture.
-	 *
-	 * @param   {Object}    [defaults={}]
-	 * the default settings of the gesture. these are added to the instance settings,
-	 * and can be overruled per instance. you can also add the name of the gesture,
-	 * but this is also added by default (and set to true).
-	 *
-	 * @param   {Function}  handler
-	 * this handles the gesture detection of your custom gesture and receives the
-	 * following arguments:
-	 *
-	 *      @param  {Object}    eventData
-	 *      event data containing the following properties:
-	 *          timeStamp   {Number}        time the event occurred
-	 *          target      {HTMLElement}   target element
-	 *          touches     {Array}         touches (fingers, pointers, mouse) on the screen
-	 *          pointerType {String}        kind of pointer that was used. matches Hammer.POINTER_MOUSE|TOUCH
-	 *          center      {Object}        center position of the touches. contains pageX and pageY
-	 *          deltaTime   {Number}        the total time of the touches in the screen
-	 *          deltaX      {Number}        the delta on x axis we haved moved
-	 *          deltaY      {Number}        the delta on y axis we haved moved
-	 *          velocityX   {Number}        the velocity on the x
-	 *          velocityY   {Number}        the velocity on y
-	 *          angle       {Number}        the angle we are moving
-	 *          direction   {String}        the direction we are moving. matches Hammer.DIRECTION_UP|DOWN|LEFT|RIGHT
-	 *          distance    {Number}        the distance we haved moved
-	 *          scale       {Number}        scaling of the touches, needs 2 touches
-	 *          rotation    {Number}        rotation of the touches, needs 2 touches *
-	 *          eventType   {String}        matches Hammer.EVENT_START|MOVE|END
-	 *          srcEvent    {Object}        the source event, like TouchStart or MouseDown *
-	 *          startEvent  {Object}        contains the same properties as above,
-	 *                                      but from the first touch. this is used to calculate
-	 *                                      distances, deltaTime, scaling etc
-	 *
-	 *      @param  {Hammer.Instance}    inst
-	 *      the instance we are doing the detection for. you can get the options from
-	 *      the inst.options object and trigger the gesture event by calling inst.trigger
-	 *
-	 *
-	 * Handle gestures
-	 * --------------------
-	 * inside the handler you can get/set Hammer.detection.current. This is the current
-	 * detection session. It has the following properties
-	 *      @param  {String}    name
-	 *      contains the name of the gesture we have detected. it has not a real function,
-	 *      only to check in other gestures if something is detected.
-	 *      like in the drag gesture we set it to 'drag' and in the swipe gesture we can
-	 *      check if the current gesture is 'drag' by accessing Hammer.detection.current.name
-	 *
-	 *      @readonly
-	 *      @param  {Hammer.Instance}    inst
-	 *      the instance we do the detection for
-	 *
-	 *      @readonly
-	 *      @param  {Object}    startEvent
-	 *      contains the properties of the first gesture detection in this session.
-	 *      Used for calculations about timing, distance, etc.
-	 *
-	 *      @readonly
-	 *      @param  {Object}    lastEvent
-	 *      contains all the properties of the last gesture detect in this session.
-	 *
-	 * after the gesture detection session has been completed (user has released the screen)
-	 * the Hammer.detection.current object is copied into Hammer.detection.previous,
-	 * this is usefull for gestures like doubletap, where you need to know if the
-	 * previous gesture was a tap
-	 *
-	 * options that have been set by the instance can be received by calling inst.options
-	 *
-	 * You can trigger a gesture event by calling inst.trigger("mygesture", event).
-	 * The first param is the name of your gesture, the second the event argument
-	 *
-	 *
-	 * Register gestures
-	 * --------------------
-	 * When an gesture is added to the Hammer.gestures object, it is auto registered
-	 * at the setup of the first Hammer instance. You can also call Hammer.detection.register
-	 * manually and pass your gesture object as a param
-	 *
-	 */
-	
-	/**
-	 * Hold
-	 * Touch stays at the same place for x time
-	 * @events  hold
-	 */
-	Hammer.gestures.Hold = {
-	    name: 'hold',
-	    index: 10,
-	    defaults: {
-	        hold_timeout	: 500,
-	        hold_threshold	: 1
-	    },
-	    timer: null,
-	    handler: function holdGesture(ev, inst) {
-	        switch(ev.eventType) {
-	            case Hammer.EVENT_START:
-	                // clear any running timers
-	                clearTimeout(this.timer);
-	
-	                // set the gesture so we can check in the timeout if it still is
-	                Hammer.detection.current.name = this.name;
-	
-	                // set timer and if after the timeout it still is hold,
-	                // we trigger the hold event
-	                this.timer = setTimeout(function() {
-	                    if(Hammer.detection.current.name == 'hold') {
-	                        inst.trigger('hold', ev);
-	                    }
-	                }, inst.options.hold_timeout);
-	                break;
-	
-	            // when you move or end we clear the timer
-	            case Hammer.EVENT_MOVE:
-	                if(ev.distance > inst.options.hold_threshold) {
-	                    clearTimeout(this.timer);
-	                }
-	                break;
-	
-	            case Hammer.EVENT_END:
-	                clearTimeout(this.timer);
-	                break;
-	        }
+
+	    this.stopped = false;
+
+	    this.current = {
+	      inst      : inst, // reference to HammerInstance we're working for
+	      startEvent: Hammer.utils.extend({}, eventData), // start eventData for distances, timing etc
+	      lastEvent : false, // last eventData
+	      name      : '' // current gesture we're in/detected, can be 'tap', 'hold' etc
+	    };
+
+	    this.detect(eventData);
+	  },
+
+
+	  /**
+	   * Hammer.gesture detection
+	   * @param   {Object}    eventData
+	   */
+	  detect: function detect(eventData) {
+	    if(!this.current || this.stopped) {
+	      return;
 	    }
-	};
-	
-	
-	/**
-	 * Tap/DoubleTap
-	 * Quick touch at a place or double at the same place
-	 * @events  tap, doubletap
-	 */
-	Hammer.gestures.Tap = {
-	    name: 'tap',
-	    index: 100,
-	    defaults: {
-	        tap_max_touchtime	: 250,
-	        tap_max_distance	: 10,
-			tap_always			: true,
-	        doubletap_distance	: 20,
-	        doubletap_interval	: 300
-	    },
-	    handler: function tapGesture(ev, inst) {
-	        if(ev.eventType == Hammer.EVENT_END) {
-	            // previous gesture, for the double tap since these are two different gesture detections
-	            var prev = Hammer.detection.previous,
-					did_doubletap = false;
-	
-	            // when the touchtime is higher then the max touch time
-	            // or when the moving distance is too much
-	            if(ev.deltaTime > inst.options.tap_max_touchtime ||
-	                ev.distance > inst.options.tap_max_distance) {
-	                return;
-	            }
-	
-	            // check if double tap
-	            if(prev && prev.name == 'tap' &&
-	                (ev.timeStamp - prev.lastEvent.timeStamp) < inst.options.doubletap_interval &&
-	                ev.distance < inst.options.doubletap_distance) {
-					inst.trigger('doubletap', ev);
-					did_doubletap = true;
-	            }
-	
-				// do a single tap
-				if(!did_doubletap || inst.options.tap_always) {
-					Hammer.detection.current.name = 'tap';
-					inst.trigger(Hammer.detection.current.name, ev);
-				}
+
+	    // extend event data with calculations about scale, distance etc
+	    eventData = this.extendEventData(eventData);
+
+	    // instance options
+	    var inst_options = this.current.inst.options;
+
+	    // call Hammer.gesture handlers
+	    Hammer.utils.each(this.gestures, function(gesture) {
+	      // only when the instance options have enabled this gesture
+	      if(!this.stopped && inst_options[gesture.name] !== false) {
+	        // if a handler returns false, we stop with the detection
+	        if(gesture.handler.call(gesture, eventData, this.current.inst) === false) {
+	          this.stopDetect();
+	          return false;
 	        }
+	      }
+	    }, this);
+
+	    // store as previous event event
+	    if(this.current) {
+	      this.current.lastEvent = eventData;
 	    }
-	};
-	
-	
-	/**
-	 * Swipe
-	 * triggers swipe events when the end velocity is above the threshold
-	 * @events  swipe, swipeleft, swiperight, swipeup, swipedown
-	 */
-	Hammer.gestures.Swipe = {
-	    name: 'swipe',
-	    index: 40,
-	    defaults: {
-	        // set 0 for unlimited, but this can conflict with transform
-	        swipe_max_touches  : 1,
-	        swipe_velocity     : 0.7
-	    },
-	    handler: function swipeGesture(ev, inst) {
-	        if(ev.eventType == Hammer.EVENT_END) {
-	            // max touches
-	            if(inst.options.swipe_max_touches > 0 &&
-	                ev.touches.length > inst.options.swipe_max_touches) {
-	                return;
-	            }
-	
-	            // when the distance we moved is too small we skip this gesture
-	            // or we can be already in dragging
-	            if(ev.velocityX > inst.options.swipe_velocity ||
-	                ev.velocityY > inst.options.swipe_velocity) {
-	                // trigger swipe events
-	                inst.trigger(this.name, ev);
-	                inst.trigger(this.name + ev.direction, ev);
-	            }
-	        }
+
+	    // endevent, but not the last touch, so dont stop
+	    if(eventData.eventType == Hammer.EVENT_END && !eventData.touches.length - 1) {
+	      this.stopDetect();
 	    }
+
+	    return eventData;
+	  },
+
+
+	  /**
+	   * clear the Hammer.gesture vars
+	   * this is called on endDetect, but can also be used when a final Hammer.gesture has been detected
+	   * to stop other Hammer.gestures from being fired
+	   */
+	  stopDetect: function stopDetect() {
+	    // clone current data to the store as the previous gesture
+	    // used for the double tap gesture, since this is an other gesture detect session
+	    this.previous = Hammer.utils.extend({}, this.current);
+
+	    // reset the current
+	    this.current = null;
+
+	    // stopped!
+	    this.stopped = true;
+	  },
+
+
+	  /**
+	   * extend eventData for Hammer.gestures
+	   * @param   {Object}   ev
+	   * @returns {Object}   ev
+	   */
+	  extendEventData: function extendEventData(ev) {
+	    var startEv = this.current.startEvent;
+
+	    // if the touches change, set the new touches over the startEvent touches
+	    // this because touchevents don't have all the touches on touchstart, or the
+	    // user must place his fingers at the EXACT same time on the screen, which is not realistic
+	    // but, sometimes it happens that both fingers are touching at the EXACT same time
+	    if(startEv && (ev.touches.length != startEv.touches.length || ev.touches === startEv.touches)) {
+	      // extend 1 level deep to get the touchlist with the touch objects
+	      startEv.touches = [];
+	      Hammer.utils.each(ev.touches, function(touch) {
+	        startEv.touches.push(Hammer.utils.extend({}, touch));
+	      });
+	    }
+
+	    var delta_time = ev.timeStamp - startEv.timeStamp
+	      , delta_x = ev.center.pageX - startEv.center.pageX
+	      , delta_y = ev.center.pageY - startEv.center.pageY
+	      , velocity = Hammer.utils.getVelocity(delta_time, delta_x, delta_y)
+	      , interimAngle
+	      , interimDirection;
+
+	    // end events (e.g. dragend) don't have useful values for interimDirection & interimAngle
+	    // because the previous event has exactly the same coordinates
+	    // so for end events, take the previous values of interimDirection & interimAngle
+	    // instead of recalculating them and getting a spurious '0'
+	    if(ev.eventType === 'end') {
+	      interimAngle = this.current.lastEvent && this.current.lastEvent.interimAngle;
+	      interimDirection = this.current.lastEvent && this.current.lastEvent.interimDirection;
+	    }
+	    else {
+	      interimAngle = this.current.lastEvent && Hammer.utils.getAngle(this.current.lastEvent.center, ev.center);
+	      interimDirection = this.current.lastEvent && Hammer.utils.getDirection(this.current.lastEvent.center, ev.center);
+	    }
+
+	    Hammer.utils.extend(ev, {
+	      deltaTime: delta_time,
+
+	      deltaX: delta_x,
+	      deltaY: delta_y,
+
+	      velocityX: velocity.x,
+	      velocityY: velocity.y,
+
+	      distance: Hammer.utils.getDistance(startEv.center, ev.center),
+
+	      angle: Hammer.utils.getAngle(startEv.center, ev.center),
+	      interimAngle: interimAngle,
+
+	      direction: Hammer.utils.getDirection(startEv.center, ev.center),
+	      interimDirection: interimDirection,
+
+	      scale: Hammer.utils.getScale(startEv.touches, ev.touches),
+	      rotation: Hammer.utils.getRotation(startEv.touches, ev.touches),
+
+	      startEvent: startEv
+	    });
+
+	    return ev;
+	  },
+
+
+	  /**
+	   * register new gesture
+	   * @param   {Object}    gesture object, see gestures.js for documentation
+	   * @returns {Array}     gestures
+	   */
+	  register: function register(gesture) {
+	    // add an enable gesture options if there is no given
+	    var options = gesture.defaults || {};
+	    if(options[gesture.name] === undefined) {
+	      options[gesture.name] = true;
+	    }
+
+	    // extend Hammer default options with the Hammer.gesture options
+	    Hammer.utils.extend(Hammer.defaults, options, true);
+
+	    // set its index
+	    gesture.index = gesture.index || 1000;
+
+	    // add Hammer.gesture to the list
+	    this.gestures.push(gesture);
+
+	    // sort the list by index
+	    this.gestures.sort(function(a, b) {
+	      if(a.index < b.index) { return -1; }
+	      if(a.index > b.index) { return 1; }
+	      return 0;
+	    });
+
+	    return this.gestures;
+	  }
 	};
-	
-	
+
+
 	/**
 	 * Drag
 	 * Move with x fingers (default 1) around on the page. Blocking the scrolling when
@@ -1171,263 +981,407 @@ webpackJsonp([1],
 	 * @events  drag, drapleft, dragright, dragup, dragdown
 	 */
 	Hammer.gestures.Drag = {
-	    name: 'drag',
-	    index: 50,
-	    defaults: {
-	        drag_min_distance : 10,
-	        // set 0 for unlimited, but this can conflict with transform
-	        drag_max_touches  : 1,
-	        // prevent default browser behavior when dragging occurs
-	        // be careful with it, it makes the element a blocking element
-	        // when you are using the drag gesture, it is a good practice to set this true
-	        drag_block_horizontal   : false,
-	        drag_block_vertical     : false,
-	        // drag_lock_to_axis keeps the drag gesture on the axis that it started on,
-	        // It disallows vertical directions if the initial direction was horizontal, and vice versa.
-	        drag_lock_to_axis       : false,
-	        // drag lock only kicks in when distance > drag_lock_min_distance
-	        // This way, locking occurs only when the distance has become large enough to reliably determine the direction
-	        drag_lock_min_distance : 25
-	    },
-	    triggered: false,
-	    handler: function dragGesture(ev, inst) {
-	        // current gesture isnt drag, but dragged is true
-	        // this means an other gesture is busy. now call dragend
-	        if(Hammer.detection.current.name != this.name && this.triggered) {
-	            inst.trigger(this.name +'end', ev);
-	            this.triggered = false;
-	            return;
-	        }
-	
-	        // max touches
-	        if(inst.options.drag_max_touches > 0 &&
-	            ev.touches.length > inst.options.drag_max_touches) {
-	            return;
-	        }
-	
-	        switch(ev.eventType) {
-	            case Hammer.EVENT_START:
-	                this.triggered = false;
-	                break;
-	
-	            case Hammer.EVENT_MOVE:
-	                // when the distance we moved is too small we skip this gesture
-	                // or we can be already in dragging
-	                if(ev.distance < inst.options.drag_min_distance &&
-	                    Hammer.detection.current.name != this.name) {
-	                    return;
-	                }
-	
-	                // we are dragging!
-	                Hammer.detection.current.name = this.name;
-	
-	                // lock drag to axis?
-	                if(Hammer.detection.current.lastEvent.drag_locked_to_axis || (inst.options.drag_lock_to_axis && inst.options.drag_lock_min_distance<=ev.distance)) {
-	                    ev.drag_locked_to_axis = true;
-	                }
-	                var last_direction = Hammer.detection.current.lastEvent.direction;
-	                if(ev.drag_locked_to_axis && last_direction !== ev.direction) {
-	                    // keep direction on the axis that the drag gesture started on
-	                    if(Hammer.utils.isVertical(last_direction)) {
-	                        ev.direction = (ev.deltaY < 0) ? Hammer.DIRECTION_UP : Hammer.DIRECTION_DOWN;
-	                    }
-	                    else {
-	                        ev.direction = (ev.deltaX < 0) ? Hammer.DIRECTION_LEFT : Hammer.DIRECTION_RIGHT;
-	                    }
-	                }
-	
-	                // first time, trigger dragstart event
-	                if(!this.triggered) {
-	                    inst.trigger(this.name +'start', ev);
-	                    this.triggered = true;
-	                }
-	
-	                // trigger normal event
-	                inst.trigger(this.name, ev);
-	
-	                // direction event, like dragdown
-	                inst.trigger(this.name + ev.direction, ev);
-	
-	                // block the browser events
-	                if( (inst.options.drag_block_vertical && Hammer.utils.isVertical(ev.direction)) ||
-	                    (inst.options.drag_block_horizontal && !Hammer.utils.isVertical(ev.direction))) {
-	                    ev.preventDefault();
-	                }
-	                break;
-	
-	            case Hammer.EVENT_END:
-	                // trigger dragend
-	                if(this.triggered) {
-	                    inst.trigger(this.name +'end', ev);
-	                }
-	
-	                this.triggered = false;
-	                break;
-	        }
+	  name     : 'drag',
+	  index    : 50,
+	  defaults : {
+	    drag_min_distance            : 10,
+	    
+	    // Set correct_for_drag_min_distance to true to make the starting point of the drag
+	    // be calculated from where the drag was triggered, not from where the touch started.
+	    // Useful to avoid a jerk-starting drag, which can make fine-adjustments
+	    // through dragging difficult, and be visually unappealing.
+	    correct_for_drag_min_distance: true,
+	    
+	    // set 0 for unlimited, but this can conflict with transform
+	    drag_max_touches             : 1,
+	    
+	    // prevent default browser behavior when dragging occurs
+	    // be careful with it, it makes the element a blocking element
+	    // when you are using the drag gesture, it is a good practice to set this true
+	    drag_block_horizontal        : false,
+	    drag_block_vertical          : false,
+	    
+	    // drag_lock_to_axis keeps the drag gesture on the axis that it started on,
+	    // It disallows vertical directions if the initial direction was horizontal, and vice versa.
+	    drag_lock_to_axis            : false,
+	    
+	    // drag lock only kicks in when distance > drag_lock_min_distance
+	    // This way, locking occurs only when the distance has become large enough to reliably determine the direction
+	    drag_lock_min_distance       : 25
+	  },
+	  
+	  triggered: false,
+	  handler  : function dragGesture(ev, inst) {
+	    // current gesture isnt drag, but dragged is true
+	    // this means an other gesture is busy. now call dragend
+	    if(Hammer.detection.current.name != this.name && this.triggered) {
+	      inst.trigger(this.name + 'end', ev);
+	      this.triggered = false;
+	      return;
 	    }
+
+	    // max touches
+	    if(inst.options.drag_max_touches > 0 &&
+	      ev.touches.length > inst.options.drag_max_touches) {
+	      return;
+	    }
+
+	    switch(ev.eventType) {
+	      case Hammer.EVENT_START:
+	        this.triggered = false;
+	        break;
+
+	      case Hammer.EVENT_MOVE:
+	        // when the distance we moved is too small we skip this gesture
+	        // or we can be already in dragging
+	        if(ev.distance < inst.options.drag_min_distance &&
+	          Hammer.detection.current.name != this.name) {
+	          return;
+	        }
+
+	        // we are dragging!
+	        if(Hammer.detection.current.name != this.name) {
+	          Hammer.detection.current.name = this.name;
+	          if(inst.options.correct_for_drag_min_distance && ev.distance > 0) {
+	            // When a drag is triggered, set the event center to drag_min_distance pixels from the original event center.
+	            // Without this correction, the dragged distance would jumpstart at drag_min_distance pixels instead of at 0.
+	            // It might be useful to save the original start point somewhere
+	            var factor = Math.abs(inst.options.drag_min_distance / ev.distance);
+	            Hammer.detection.current.startEvent.center.pageX += ev.deltaX * factor;
+	            Hammer.detection.current.startEvent.center.pageY += ev.deltaY * factor;
+
+	            // recalculate event data using new start point
+	            ev = Hammer.detection.extendEventData(ev);
+	          }
+	        }
+
+	        // lock drag to axis?
+	        if(Hammer.detection.current.lastEvent.drag_locked_to_axis || (inst.options.drag_lock_to_axis && inst.options.drag_lock_min_distance <= ev.distance)) {
+	          ev.drag_locked_to_axis = true;
+	        }
+	        var last_direction = Hammer.detection.current.lastEvent.direction;
+	        if(ev.drag_locked_to_axis && last_direction !== ev.direction) {
+	          // keep direction on the axis that the drag gesture started on
+	          if(Hammer.utils.isVertical(last_direction)) {
+	            ev.direction = (ev.deltaY < 0) ? Hammer.DIRECTION_UP : Hammer.DIRECTION_DOWN;
+	          }
+	          else {
+	            ev.direction = (ev.deltaX < 0) ? Hammer.DIRECTION_LEFT : Hammer.DIRECTION_RIGHT;
+	          }
+	        }
+
+	        // first time, trigger dragstart event
+	        if(!this.triggered) {
+	          inst.trigger(this.name + 'start', ev);
+	          this.triggered = true;
+	        }
+
+	        // trigger normal event
+	        inst.trigger(this.name, ev);
+
+	        // direction event, like dragdown
+	        inst.trigger(this.name + ev.direction, ev);
+
+	        // block the browser events
+	        if((inst.options.drag_block_vertical && Hammer.utils.isVertical(ev.direction)) ||
+	          (inst.options.drag_block_horizontal && !Hammer.utils.isVertical(ev.direction))) {
+	          ev.preventDefault();
+	        }
+	        break;
+
+	      case Hammer.EVENT_END:
+	        // trigger dragend
+	        if(this.triggered) {
+	          inst.trigger(this.name + 'end', ev);
+	        }
+
+	        this.triggered = false;
+	        break;
+	    }
+	  }
 	};
-	
-	
+
 	/**
-	 * Transform
-	 * User want to scale or rotate with 2 fingers
-	 * @events  transform, pinch, pinchin, pinchout, rotate
+	 * Hold
+	 * Touch stays at the same place for x time
+	 * @events  hold
 	 */
-	Hammer.gestures.Transform = {
-	    name: 'transform',
-	    index: 45,
-	    defaults: {
-	        // factor, no scale is 1, zoomin is to 0 and zoomout until higher then 1
-	        transform_min_scale     : 0.01,
-	        // rotation in degrees
-	        transform_min_rotation  : 1,
-	        // prevent default browser behavior when two touches are on the screen
-	        // but it makes the element a blocking element
-	        // when you are using the transform gesture, it is a good practice to set this true
-	        transform_always_block  : false
-	    },
-	    triggered: false,
-	    handler: function transformGesture(ev, inst) {
-	        // current gesture isnt drag, but dragged is true
-	        // this means an other gesture is busy. now call dragend
-	        if(Hammer.detection.current.name != this.name && this.triggered) {
-	            inst.trigger(this.name +'end', ev);
-	            this.triggered = false;
-	            return;
+	Hammer.gestures.Hold = {
+	  name    : 'hold',
+	  index   : 10,
+	  defaults: {
+	    hold_timeout  : 500,
+	    hold_threshold: 1
+	  },
+	  timer   : null,
+	  handler : function holdGesture(ev, inst) {
+	    switch(ev.eventType) {
+	      case Hammer.EVENT_START:
+	        // clear any running timers
+	        clearTimeout(this.timer);
+
+	        // set the gesture so we can check in the timeout if it still is
+	        Hammer.detection.current.name = this.name;
+
+	        // set timer and if after the timeout it still is hold,
+	        // we trigger the hold event
+	        this.timer = setTimeout(function() {
+	          if(Hammer.detection.current.name == 'hold') {
+	            inst.trigger('hold', ev);
+	          }
+	        }, inst.options.hold_timeout);
+	        break;
+
+	      // when you move or end we clear the timer
+	      case Hammer.EVENT_MOVE:
+	        if(ev.distance > inst.options.hold_threshold) {
+	          clearTimeout(this.timer);
 	        }
-	
-	        // atleast multitouch
-	        if(ev.touches.length < 2) {
-	            return;
-	        }
-	
-	        // prevent default when two fingers are on the screen
-	        if(inst.options.transform_always_block) {
-	            ev.preventDefault();
-	        }
-	
-	        switch(ev.eventType) {
-	            case Hammer.EVENT_START:
-	                this.triggered = false;
-	                break;
-	
-	            case Hammer.EVENT_MOVE:
-	                var scale_threshold = Math.abs(1-ev.scale);
-	                var rotation_threshold = Math.abs(ev.rotation);
-	
-	                // when the distance we moved is too small we skip this gesture
-	                // or we can be already in dragging
-	                if(scale_threshold < inst.options.transform_min_scale &&
-	                    rotation_threshold < inst.options.transform_min_rotation) {
-	                    return;
-	                }
-	
-	                // we are transforming!
-	                Hammer.detection.current.name = this.name;
-	
-	                // first time, trigger dragstart event
-	                if(!this.triggered) {
-	                    inst.trigger(this.name +'start', ev);
-	                    this.triggered = true;
-	                }
-	
-	                inst.trigger(this.name, ev); // basic transform event
-	
-	                // trigger rotate event
-	                if(rotation_threshold > inst.options.transform_min_rotation) {
-	                    inst.trigger('rotate', ev);
-	                }
-	
-	                // trigger pinch event
-	                if(scale_threshold > inst.options.transform_min_scale) {
-	                    inst.trigger('pinch', ev);
-	                    inst.trigger('pinch'+ ((ev.scale < 1) ? 'in' : 'out'), ev);
-	                }
-	                break;
-	
-	            case Hammer.EVENT_END:
-	                // trigger dragend
-	                if(this.triggered) {
-	                    inst.trigger(this.name +'end', ev);
-	                }
-	
-	                this.triggered = false;
-	                break;
-	        }
+	        break;
+
+	      case Hammer.EVENT_END:
+	        clearTimeout(this.timer);
+	        break;
 	    }
+	  }
 	};
-	
-	
-	/**
-	 * Touch
-	 * Called as first, tells the user has touched the screen
-	 * @events  touch
-	 */
-	Hammer.gestures.Touch = {
-	    name: 'touch',
-	    index: -Infinity,
-	    defaults: {
-	        // call preventDefault at touchstart, and makes the element blocking by
-	        // disabling the scrolling of the page, but it improves gestures like
-	        // transforming and dragging.
-	        // be careful with using this, it can be very annoying for users to be stuck
-	        // on the page
-	        prevent_default: false,
-	
-	        // disable mouse events, so only touch (or pen!) input triggers events
-	        prevent_mouseevents: false
-	    },
-	    handler: function touchGesture(ev, inst) {
-	        if(inst.options.prevent_mouseevents && ev.pointerType == Hammer.POINTER_MOUSE) {
-	            ev.stopDetect();
-	            return;
-	        }
-	
-	        if(inst.options.prevent_default) {
-	            ev.preventDefault();
-	        }
-	
-	        if(ev.eventType ==  Hammer.EVENT_START) {
-	            inst.trigger(this.name, ev);
-	        }
-	    }
-	};
-	
-	
+
 	/**
 	 * Release
 	 * Called as last, tells the user has released the screen
 	 * @events  release
 	 */
 	Hammer.gestures.Release = {
-	    name: 'release',
-	    index: Infinity,
-	    handler: function releaseGesture(ev, inst) {
-	        if(ev.eventType ==  Hammer.EVENT_END) {
-	            inst.trigger(this.name, ev);
-	        }
+	  name   : 'release',
+	  index  : Infinity,
+	  handler: function releaseGesture(ev, inst) {
+	    if(ev.eventType == Hammer.EVENT_END) {
+	      inst.trigger(this.name, ev);
 	    }
+	  }
 	};
-	
-	// node export
-	if(typeof module === 'object' && typeof module.exports === 'object'){
-	    module.exports = Hammer;
-	}
-	// just window export
-	else {
-	    window.Hammer = Hammer;
-	
-	    // requireJS module definition
-	    if(typeof window.define === 'function' && window.define.amd) {
-	        window.define('hammer', [], function() {
-	            return Hammer;
-	        });
+
+	/**
+	 * Swipe
+	 * triggers swipe events when the end velocity is above the threshold
+	 * @events  swipe, swipeleft, swiperight, swipeup, swipedown
+	 */
+	Hammer.gestures.Swipe = {
+	  name    : 'swipe',
+	  index   : 40,
+	  defaults: {
+	    // set 0 for unlimited, but this can conflict with transform
+	    swipe_min_touches: 1,
+	    swipe_max_touches: 1,
+	    swipe_velocity   : 0.7
+	  },
+	  handler : function swipeGesture(ev, inst) {
+	    if(ev.eventType == Hammer.EVENT_END) {
+	      // max touches
+	      if(inst.options.swipe_max_touches > 0 &&
+	        ev.touches.length < inst.options.swipe_min_touches &&
+	        ev.touches.length > inst.options.swipe_max_touches) {
+	        return;
+	      }
+
+	      // when the distance we moved is too small we skip this gesture
+	      // or we can be already in dragging
+	      if(ev.velocityX > inst.options.swipe_velocity ||
+	        ev.velocityY > inst.options.swipe_velocity) {
+	        // trigger swipe events
+	        inst.trigger(this.name, ev);
+	        inst.trigger(this.name + ev.direction, ev);
+	      }
 	    }
-	}
+	  }
+	};
+
+	/**
+	 * Tap/DoubleTap
+	 * Quick touch at a place or double at the same place
+	 * @events  tap, doubletap
+	 */
+	Hammer.gestures.Tap = {
+	  name    : 'tap',
+	  index   : 100,
+	  defaults: {
+	    tap_max_touchtime : 250,
+	    tap_max_distance  : 10,
+	    tap_always        : true,
+	    doubletap_distance: 20,
+	    doubletap_interval: 300
+	  },
+	  handler : function tapGesture(ev, inst) {
+	    if(ev.eventType == Hammer.EVENT_END && ev.srcEvent.type != 'touchcancel') {
+	      // previous gesture, for the double tap since these are two different gesture detections
+	      var prev = Hammer.detection.previous,
+	        did_doubletap = false;
+
+	      // when the touchtime is higher then the max touch time
+	      // or when the moving distance is too much
+	      if(ev.deltaTime > inst.options.tap_max_touchtime ||
+	        ev.distance > inst.options.tap_max_distance) {
+	        return;
+	      }
+
+	      // check if double tap
+	      if(prev && prev.name == 'tap' &&
+	        (ev.timeStamp - prev.lastEvent.timeStamp) < inst.options.doubletap_interval &&
+	        ev.distance < inst.options.doubletap_distance) {
+	        inst.trigger('doubletap', ev);
+	        did_doubletap = true;
+	      }
+
+	      // do a single tap
+	      if(!did_doubletap || inst.options.tap_always) {
+	        Hammer.detection.current.name = 'tap';
+	        inst.trigger(Hammer.detection.current.name, ev);
+	      }
+	    }
+	  }
+	};
+
+	/**
+	 * Touch
+	 * Called as first, tells the user has touched the screen
+	 * @events  touch
+	 */
+	Hammer.gestures.Touch = {
+	  name    : 'touch',
+	  index   : -Infinity,
+	  defaults: {
+	    // call preventDefault at touchstart, and makes the element blocking by
+	    // disabling the scrolling of the page, but it improves gestures like
+	    // transforming and dragging.
+	    // be careful with using this, it can be very annoying for users to be stuck
+	    // on the page
+	    prevent_default    : false,
+
+	    // disable mouse events, so only touch (or pen!) input triggers events
+	    prevent_mouseevents: false
+	  },
+	  handler : function touchGesture(ev, inst) {
+	    if(inst.options.prevent_mouseevents && ev.pointerType == Hammer.POINTER_MOUSE) {
+	      ev.stopDetect();
+	      return;
+	    }
+
+	    if(inst.options.prevent_default) {
+	      ev.preventDefault();
+	    }
+
+	    if(ev.eventType == Hammer.EVENT_START) {
+	      inst.trigger(this.name, ev);
+	    }
+	  }
+	};
+
+	/**
+	 * Transform
+	 * User want to scale or rotate with 2 fingers
+	 * @events  transform, pinch, pinchin, pinchout, rotate
+	 */
+	Hammer.gestures.Transform = {
+	  name     : 'transform',
+	  index    : 45,
+	  defaults : {
+	    // factor, no scale is 1, zoomin is to 0 and zoomout until higher then 1
+	    transform_min_scale   : 0.01,
+	    // rotation in degrees
+	    transform_min_rotation: 1,
+	    // prevent default browser behavior when two touches are on the screen
+	    // but it makes the element a blocking element
+	    // when you are using the transform gesture, it is a good practice to set this true
+	    transform_always_block: false
+	  },
+	  triggered: false,
+	  handler  : function transformGesture(ev, inst) {
+	    // current gesture isnt drag, but dragged is true
+	    // this means an other gesture is busy. now call dragend
+	    if(Hammer.detection.current.name != this.name && this.triggered) {
+	      inst.trigger(this.name + 'end', ev);
+	      this.triggered = false;
+	      return;
+	    }
+
+	    // atleast multitouch
+	    if(ev.touches.length < 2) {
+	      return;
+	    }
+
+	    // prevent default when two fingers are on the screen
+	    if(inst.options.transform_always_block) {
+	      ev.preventDefault();
+	    }
+
+	    switch(ev.eventType) {
+	      case Hammer.EVENT_START:
+	        this.triggered = false;
+	        break;
+
+	      case Hammer.EVENT_MOVE:
+	        var scale_threshold = Math.abs(1 - ev.scale);
+	        var rotation_threshold = Math.abs(ev.rotation);
+
+	        // when the distance we moved is too small we skip this gesture
+	        // or we can be already in dragging
+	        if(scale_threshold < inst.options.transform_min_scale &&
+	          rotation_threshold < inst.options.transform_min_rotation) {
+	          return;
+	        }
+
+	        // we are transforming!
+	        Hammer.detection.current.name = this.name;
+
+	        // first time, trigger dragstart event
+	        if(!this.triggered) {
+	          inst.trigger(this.name + 'start', ev);
+	          this.triggered = true;
+	        }
+
+	        inst.trigger(this.name, ev); // basic transform event
+
+	        // trigger rotate event
+	        if(rotation_threshold > inst.options.transform_min_rotation) {
+	          inst.trigger('rotate', ev);
+	        }
+
+	        // trigger pinch event
+	        if(scale_threshold > inst.options.transform_min_scale) {
+	          inst.trigger('pinch', ev);
+	          inst.trigger('pinch' + ((ev.scale < 1) ? 'in' : 'out'), ev);
+	        }
+	        break;
+
+	      case Hammer.EVENT_END:
+	        // trigger dragend
+	        if(this.triggered) {
+	          inst.trigger(this.name + 'end', ev);
+	        }
+
+	        this.triggered = false;
+	        break;
+	    }
+	  }
+	};
+
+	  // Based off Lo-Dash's excellent UMD wrapper (slightly modified) - https://github.com/bestiejs/lodash/blob/master/lodash.js#L5515-L5543
+	  // some AMD build optimizers, like r.js, check for specific condition patterns like the following:
+	  if(true) {
+	    // define as an anonymous module
+	    (__WEBPACK_AMD_DEFINE_RESULT__ = (function() {
+	      return Hammer;
+	    }.call(exports, require, exports, module)), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+	    // check for `exports` after `define` in case a build optimizer adds an `exports` object
+	  }
+	  else if(typeof module === 'object' && typeof module.exports === 'object') {
+	    module.exports = Hammer;
+	  }
+	  else {
+	    window.Hammer = Hammer;
+	  }
 	})(this);
-	/* WEBPACK VAR INJECTION */}(require, require(5)(module)))
 
 /***/ }
 
-}
-)
+})

--- a/bundle.js
+++ b/bundle.js
@@ -1,11 +1,14 @@
 /******/ (function(modules) { // webpackBootstrap
+/******/ 	
 /******/ 	// The module cache
 /******/ 	var installedModules = {};
 /******/ 	
 /******/ 	// object to store loaded and loading chunks
 /******/ 	// "0" means "already loaded"
 /******/ 	// Array means "loading", array contains callbacks
-/******/ 	var installedChunks = {0:0};
+/******/ 	var installedChunks = {
+/******/ 		0:0
+/******/ 	};
 /******/ 	
 /******/ 	// The require function
 /******/ 	function require(moduleId) {
@@ -21,7 +24,7 @@
 /******/ 		};
 /******/ 		
 /******/ 		// Execute the module function
-/******/ 		modules[moduleId].call(null, module, module.exports, require);
+/******/ 		modules[moduleId].call(module.exports, module, module.exports, require);
 /******/ 		
 /******/ 		// Flag the module as loaded
 /******/ 		module.loaded = true;
@@ -47,7 +50,7 @@
 /******/ 			var script = document.createElement('script');
 /******/ 			script.type = 'text/javascript';
 /******/ 			script.charset = 'utf-8';
-/******/ 			script.src = modules.c + "" + chunkId + ".bundle.js";
+/******/ 			script.src = require.p + "" + chunkId + ".bundle.js";
 /******/ 			head.appendChild(script);
 /******/ 		}
 /******/ 	};
@@ -57,6 +60,9 @@
 /******/ 	
 /******/ 	// expose the module cache
 /******/ 	require.cache = installedModules;
+/******/ 	
+/******/ 	// __webpack_public_path__
+/******/ 	require.p = "";
 /******/ 	
 /******/ 	// install a JSONP callback for chunk loading
 /******/ 	window["webpackJsonp"] = function webpackJsonpCallback(chunkIds, moreModules) {
@@ -80,74 +86,70 @@
 /******/ 	return require(0);
 /******/ })
 /************************************************************************/
-/******/ ({
-/******/ // __webpack_public_path__
-/******/ c: "",
-
-/***/ 0:
+/******/ ([
+/* 0 */
 /***/ function(module, exports, require) {
 
 	// Run Modernizr on our page
 	require(1);
-	
+
 	// Require jquery and Backbone
 	var $ = require(2),
-	    Backbone = require(6); // Use backbone from npm
-	
+	    Backbone = require(5); // Use backbone from npm
+
 	// Include jquery.scrollTo (does not export anything)
 	require(3);
-	
-	
+
+
 	// Simple example:
 	var MyView  = Backbone.View.extend({/* ... */}),
 	    MyModel = Backbone.Model.extend({/* ... */});
-	
+
 	// Much better:
 	// var MyView  = require('./src/MyView'),
 	//     MyModel = require('./src/MyModel'),
-	
-	
+
+
 	// DOM ready - start things up
 	$(function(){
 	    var view  = new MyView(),
 	        model = new MyModel();
-	
+
 	    console.log("Backbone modules initialized");
 	});
-	
-	
+
+
 	// Code-splitting example
 	//
 	// For touch devices, load hammerjs ASYNCHRONOUSLY
 	if (Modernizr.touch) {
 	    console.log("Loading touch libraries");
-	
+
 	    require.e/*nsure*/(1, function(require){
-	
+
 	        // require.ensure creates a bundle split-point
-	        var Hammer = require(7);
-	
+	        var Hammer = require(6);
+
 	        // Hammer loaded via XHR - ready to initialize
 	        // Hammer(/* ... */);
 	    });
-	
+
 	} else {
 	    console.log("No touch features detected - skipping unneeded libraries");
 	}
 
 /***/ },
-
-/***/ 1:
+/* 1 */
 /***/ function(module, exports, require) {
 
 	/*!
-	 * Modernizr v2.6.2
+	 * Modernizr v2.6.3
 	 * www.modernizr.com
 	 *
 	 * Copyright (c) Faruk Ates, Paul Irish, Alex Sexton
 	 * Available under the BSD and MIT licenses: www.modernizr.com/license/
 	 */
-	
+
 	/*
 	 * Modernizr tests which native CSS3 and HTML5 features are available in
 	 * the current UA and makes the results available to you in two ways:
@@ -163,88 +165,88 @@
 	 * Authors        Faruk Ates, Paul Irish, Alex Sexton
 	 * Contributors   Ryan Seddon, Ben Alman
 	 */
-	
+
 	window.Modernizr = (function( window, document, undefined ) {
-	
-	    var version = '2.6.2',
-	
+
+	    var version = '2.6.3',
+
 	    Modernizr = {},
-	
+
 	    /*>>cssclasses*/
 	    // option for enabling the HTML classes to be added
 	    enableClasses = true,
 	    /*>>cssclasses*/
-	
+
 	    docElement = document.documentElement,
-	
+
 	    /**
 	     * Create our "modernizr" element that we do most feature tests on.
 	     */
 	    mod = 'modernizr',
 	    modElem = document.createElement(mod),
 	    mStyle = modElem.style,
-	
+
 	    /**
 	     * Create the input element for various Web Forms feature tests.
 	     */
 	    inputElem /*>>inputelem*/ = document.createElement('input') /*>>inputelem*/ ,
-	
+
 	    /*>>smile*/
 	    smile = ':)',
 	    /*>>smile*/
-	
+
 	    toString = {}.toString,
-	
+
 	    // TODO :: make the prefixes more granular
 	    /*>>prefixes*/
 	    // List of property values to set for css tests. See ticket #21
 	    prefixes = ' -webkit- -moz- -o- -ms- '.split(' '),
 	    /*>>prefixes*/
-	
+
 	    /*>>domprefixes*/
 	    // Following spec is to expose vendor-specific style properties as:
 	    //   elem.style.WebkitBorderRadius
 	    // and the following would be incorrect:
 	    //   elem.style.webkitBorderRadius
-	
+
 	    // Webkit ghosts their properties in lowercase but Opera & Moz do not.
 	    // Microsoft uses a lowercase `ms` instead of the correct `Ms` in IE8+
 	    //   erik.eae.net/archives/2008/03/10/21.48.10/
-	
+
 	    // More here: github.com/Modernizr/Modernizr/issues/issue/21
 	    omPrefixes = 'Webkit Moz O ms',
-	
+
 	    cssomPrefixes = omPrefixes.split(' '),
-	
+
 	    domPrefixes = omPrefixes.toLowerCase().split(' '),
 	    /*>>domprefixes*/
-	
+
 	    /*>>ns*/
 	    ns = {'svg': 'http://www.w3.org/2000/svg'},
 	    /*>>ns*/
-	
+
 	    tests = {},
 	    inputs = {},
 	    attrs = {},
-	
+
 	    classes = [],
-	
+
 	    slice = classes.slice,
-	
+
 	    featureName, // used in testing loop
-	
-	
+
+
 	    /*>>teststyles*/
 	    // Inject element with style element and some CSS rules
 	    injectElementWithStyles = function( rule, callback, nodes, testnames ) {
-	
+
 	      var style, ret, node, docOverflow,
 	          div = document.createElement('div'),
 	          // After page load injecting a fake body doesn't work so check if body exists
 	          body = document.body,
 	          // IE6 and 7 won't return offsetWidth or offsetHeight unless it's in the body element, so we fake it.
 	          fakeBody = body || document.createElement('body');
-	
+
 	      if ( parseInt(nodes, 10) ) {
 	          // In order not to give false positives we create a node for each test
 	          // This also allows the method to scale for unspecified uses
@@ -254,7 +256,7 @@
 	              div.appendChild(node);
 	          }
 	      }
-	
+
 	      // <style> elements in IE6-9 are considered 'NoScope' elements and therefore will be removed
 	      // when injected with innerHTML. To get around this you need to prepend the 'NoScope' element
 	      // with a 'scoped' element, in our case the soft-hyphen entity as it won't mess with our measurements.
@@ -275,7 +277,7 @@
 	          docElement.style.overflow = 'hidden';
 	          docElement.appendChild(fakeBody);
 	      }
-	
+
 	      ret = callback(div, rule);
 	      // If this is done after page load we don't want to remove the body so check if body exists
 	      if ( !body ) {
@@ -284,37 +286,37 @@
 	      } else {
 	          div.parentNode.removeChild(div);
 	      }
-	
+
 	      return !!ret;
-	
+
 	    },
 	    /*>>teststyles*/
-	
+
 	    /*>>mq*/
 	    // adapted from matchMedia polyfill
 	    // by Scott Jehl and Paul Irish
 	    // gist.github.com/786768
 	    testMediaQuery = function( mq ) {
-	
+
 	      var matchMedia = window.matchMedia || window.msMatchMedia;
 	      if ( matchMedia ) {
 	        return matchMedia(mq).matches;
 	      }
-	
+
 	      var bool;
-	
+
 	      injectElementWithStyles('@media ' + mq + ' { #' + mod + ' { position: absolute; } }', function( node ) {
 	        bool = (window.getComputedStyle ?
 	                  getComputedStyle(node, null) :
 	                  node.currentStyle)['position'] == 'absolute';
 	      });
-	
+
 	      return bool;
-	
+
 	     },
 	     /*>>mq*/
-	
-	
+
+
 	    /*>>hasevent*/
 	    //
 	    // isEventSupported determines if a given element supports the given event
@@ -325,21 +327,21 @@
 	    //   Modernizr.hasEvent("textInput") // in Webkit. github.com/Modernizr/Modernizr/issues/333
 	    //   ...
 	    isEventSupported = (function() {
-	
+
 	      var TAGNAMES = {
 	        'select': 'input', 'change': 'input',
 	        'submit': 'form', 'reset': 'form',
 	        'error': 'img', 'load': 'img', 'abort': 'img'
 	      };
-	
+
 	      function isEventSupported( eventName, element ) {
-	
+
 	        element = element || document.createElement(TAGNAMES[eventName] || 'div');
 	        eventName = 'on' + eventName;
-	
+
 	        // When using `setAttribute`, IE skips "unload", WebKit skips "unload" and "resize", whereas `in` "catches" those
 	        var isSupported = eventName in element;
-	
+
 	        if ( !isSupported ) {
 	          // If it has no `setAttribute` (i.e. doesn't implement Node interface), try generic element
 	          if ( !element.setAttribute ) {
@@ -348,7 +350,7 @@
 	          if ( element.setAttribute && element.removeAttribute ) {
 	            element.setAttribute(eventName, '');
 	            isSupported = is(element[eventName], 'function');
-	
+
 	            // If property was created, "remove it" (by setting value to `undefined`)
 	            if ( !is(element[eventName], 'undefined') ) {
 	              element[eventName] = undefined;
@@ -356,19 +358,19 @@
 	            element.removeAttribute(eventName);
 	          }
 	        }
-	
+
 	        element = null;
 	        return isSupported;
 	      }
 	      return isEventSupported;
 	    })(),
 	    /*>>hasevent*/
-	
+
 	    // TODO :: Add flag for hasownprop ? didn't last time
-	
+
 	    // hasOwnProperty shim by kangax needed for Safari 2.0 support
 	    _hasOwnProperty = ({}).hasOwnProperty, hasOwnProp;
-	
+
 	    if ( !is(_hasOwnProperty, 'undefined') && !is(_hasOwnProperty.call, 'undefined') ) {
 	      hasOwnProp = function (object, property) {
 	        return _hasOwnProperty.call(object, property);
@@ -379,28 +381,28 @@
 	        return ((property in object) && is(object.constructor.prototype[property], 'undefined'));
 	      };
 	    }
-	
+
 	    // Adapted from ES5-shim https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js
 	    // es5.github.com/#x15.3.4.5
-	
+
 	    if (!Function.prototype.bind) {
 	      Function.prototype.bind = function bind(that) {
-	
+
 	        var target = this;
-	
+
 	        if (typeof target != "function") {
 	            throw new TypeError();
 	        }
-	
+
 	        var args = slice.call(arguments, 1),
 	            bound = function () {
-	
+
 	            if (this instanceof bound) {
-	
+
 	              var F = function(){};
 	              F.prototype = target.prototype;
 	              var self = new F();
-	
+
 	              var result = target.apply(
 	                  self,
 	                  args.concat(slice.call(arguments))
@@ -409,70 +411,70 @@
 	                  return result;
 	              }
 	              return self;
-	
+
 	            } else {
-	
+
 	              return target.apply(
 	                  that,
 	                  args.concat(slice.call(arguments))
 	              );
-	
+
 	            }
-	
+
 	        };
-	
+
 	        return bound;
 	      };
 	    }
-	
+
 	    /**
 	     * setCss applies given styles to the Modernizr DOM node.
 	     */
 	    function setCss( str ) {
 	        mStyle.cssText = str;
 	    }
-	
+
 	    /**
 	     * setCssAll extrapolates all vendor-specific css strings.
 	     */
 	    function setCssAll( str1, str2 ) {
 	        return setCss(prefixes.join(str1 + ';') + ( str2 || '' ));
 	    }
-	
+
 	    /**
 	     * is returns a boolean for if typeof obj is exactly type.
 	     */
 	    function is( obj, type ) {
 	        return typeof obj === type;
 	    }
-	
+
 	    /**
 	     * contains returns a boolean for if substr is found within str.
 	     */
 	    function contains( str, substr ) {
 	        return !!~('' + str).indexOf(substr);
 	    }
-	
+
 	    /*>>testprop*/
-	
+
 	    // testProps is a generic CSS / DOM property test.
-	
+
 	    // In testing support for a given CSS property, it's legit to test:
 	    //    `elem.style[styleName] !== undefined`
 	    // If the property is supported it will return an empty string,
 	    // if unsupported it will return undefined.
-	
+
 	    // We'll take advantage of this quick test and skip setting a style
 	    // on our modernizr element, but instead just testing undefined vs
 	    // empty string.
-	
+
 	    // Because the testing of the CSS property names (with "-", as
 	    // opposed to the camelCase DOM properties) is non-portable and
 	    // non-standard but works in WebKit and IE (but not Gecko or Opera),
 	    // we explicitly reject properties with dashes so that authors
 	    // developing in WebKit or IE first don't end up with
 	    // browser-specific content by accident.
-	
+
 	    function testProps( props, prefixed ) {
 	        for ( var i in props ) {
 	            var prop = props[i];
@@ -483,7 +485,7 @@
 	        return false;
 	    }
 	    /*>>testprop*/
-	
+
 	    // TODO :: add testDOMProps
 	    /**
 	     * testDOMProps is a generic DOM property test; if a browser supports
@@ -493,23 +495,23 @@
 	        for ( var i in props ) {
 	            var item = obj[props[i]];
 	            if ( item !== undefined) {
-	
+
 	                // return the property name as a string
 	                if (elem === false) return props[i];
-	
+
 	                // let's bind a function
 	                if (is(item, 'function')){
 	                  // default to autobind unless override
 	                  return item.bind(elem || obj);
 	                }
-	
+
 	                // return the unbound function or obj or value
 	                return item;
 	            }
 	        }
 	        return false;
 	    }
-	
+
 	    /*>>testallprops*/
 	    /**
 	     * testPropsAll tests a list of DOM properties we want to check against.
@@ -518,14 +520,14 @@
 	     *   compatibility.
 	     */
 	    function testPropsAll( prop, prefixed, elem ) {
-	
+
 	        var ucProp  = prop.charAt(0).toUpperCase() + prop.slice(1),
 	            props   = (prop + ' ' + cssomPrefixes.join(ucProp + ' ') + ucProp).split(' ');
-	
+
 	        // did they call .prefixed('boxSizing') or are we just testing a prop?
 	        if(is(prefixed, "string") || is(prefixed, "undefined")) {
 	          return testProps(props, prefixed);
-	
+
 	        // otherwise, they called .prefixed('requestAnimationFrame', window[, elem])
 	        } else {
 	          props = (prop + ' ' + (domPrefixes).join(ucProp + ' ') + ucProp).split(' ');
@@ -533,49 +535,49 @@
 	        }
 	    }
 	    /*>>testallprops*/
-	
-	
+
+
 	    /**
 	     * Tests
 	     * -----
 	     */
-	
+
 	    // The *new* flexbox
 	    // dev.w3.org/csswg/css3-flexbox
-	
+
 	    tests['flexbox'] = function() {
 	      return testPropsAll('flexWrap');
 	    };
-	
+
 	    // The *old* flexbox
 	    // www.w3.org/TR/2009/WD-css3-flexbox-20090723/
-	
+
 	    tests['flexboxlegacy'] = function() {
 	        return testPropsAll('boxDirection');
 	    };
-	
+
 	    // On the S60 and BB Storm, getContext exists, but always returns undefined
 	    // so we actually have to call getContext() to verify
 	    // github.com/Modernizr/Modernizr/issues/issue/97/
-	
+
 	    tests['canvas'] = function() {
 	        var elem = document.createElement('canvas');
 	        return !!(elem.getContext && elem.getContext('2d'));
 	    };
-	
+
 	    tests['canvastext'] = function() {
 	        return !!(Modernizr['canvas'] && is(document.createElement('canvas').getContext('2d').fillText, 'function'));
 	    };
-	
+
 	    // webk.it/70117 is tracking a legit WebGL feature detect proposal
-	
+
 	    // We do a soft detect which may false positive in order to avoid
 	    // an expensive context creation: bugzil.la/732441
-	
+
 	    tests['webgl'] = function() {
 	        return !!window.WebGLRenderingContext;
 	    };
-	
+
 	    /*
 	     * The Modernizr.touch test only indicates if the browser supports
 	     *    touch events, which does not necessarily reflect a touchscreen
@@ -589,10 +591,10 @@
 	     *
 	     * For more info, see: modernizr.github.com/Modernizr/touch.html
 	     */
-	
+
 	    tests['touch'] = function() {
 	        var bool;
-	
+
 	        if(('ontouchstart' in window) || window.DocumentTouch && document instanceof DocumentTouch) {
 	          bool = true;
 	        } else {
@@ -600,11 +602,11 @@
 	            bool = node.offsetTop === 9;
 	          });
 	        }
-	
+
 	        return bool;
 	    };
-	
-	
+
+
 	    // geolocation is often considered a trivial feature detect...
 	    // Turns out, it's quite tricky to get right:
 	    //
@@ -614,23 +616,23 @@
 	    //
 	    // Meanwhile, in Firefox < 8, an about:config setting could expose
 	    // a false positive that would throw an exception: bugzil.la/688158
-	
+
 	    tests['geolocation'] = function() {
 	        return 'geolocation' in navigator;
 	    };
-	
-	
+
+
 	    tests['postmessage'] = function() {
 	      return !!window.postMessage;
 	    };
-	
-	
+
+
 	    // Chrome incognito mode used to throw an exception when using openDatabase
 	    // It doesn't anymore.
 	    tests['websqldatabase'] = function() {
 	      return !!window.openDatabase;
 	    };
-	
+
 	    // Vendors had inconsistent prefixing with the experimental Indexed DB:
 	    // - Webkit's implementation is accessible through webkitIndexedDB
 	    // - Firefox shipped moz_indexedDB before FF4b9, but since then has been mozIndexedDB
@@ -638,13 +640,13 @@
 	    tests['indexedDB'] = function() {
 	      return !!testPropsAll("indexedDB", window);
 	    };
-	
+
 	    // documentMode logic from YUI to filter out IE8 Compat Mode
 	    //   which false positives.
 	    tests['hashchange'] = function() {
 	      return isEventSupported('hashchange', window) && (document.documentMode === undefined || document.documentMode > 7);
 	    };
-	
+
 	    // Per 1.6:
 	    // This used to be Modernizr.historymanagement but the longer
 	    // name has been deprecated in favor of a shorter and property-matching one.
@@ -653,12 +655,12 @@
 	    tests['history'] = function() {
 	      return !!(window.history && history.pushState);
 	    };
-	
+
 	    tests['draganddrop'] = function() {
 	        var div = document.createElement('div');
 	        return ('draggable' in div) || ('ondragstart' in div && 'ondrop' in div);
 	    };
-	
+
 	    // FF3.6 was EOL'ed on 4/24/12, but the ESR version of FF10
 	    // will be supported until FF19 (2/12/13), at which time, ESR becomes FF17.
 	    // FF10 still uses prefixes, so check for it until then.
@@ -666,98 +668,98 @@
 	    tests['websockets'] = function() {
 	        return 'WebSocket' in window || 'MozWebSocket' in window;
 	    };
-	
-	
+
+
 	    // css-tricks.com/rgba-browser-support/
 	    tests['rgba'] = function() {
 	        // Set an rgba() color and check the returned value
-	
+
 	        setCss('background-color:rgba(150,255,150,.5)');
-	
+
 	        return contains(mStyle.backgroundColor, 'rgba');
 	    };
-	
+
 	    tests['hsla'] = function() {
 	        // Same as rgba(), in fact, browsers re-map hsla() to rgba() internally,
 	        //   except IE9 who retains it as hsla
-	
+
 	        setCss('background-color:hsla(120,40%,100%,.5)');
-	
+
 	        return contains(mStyle.backgroundColor, 'rgba') || contains(mStyle.backgroundColor, 'hsla');
 	    };
-	
+
 	    tests['multiplebgs'] = function() {
 	        // Setting multiple images AND a color on the background shorthand property
 	        //  and then querying the style.background property value for the number of
 	        //  occurrences of "url(" is a reliable method for detecting ACTUAL support for this!
-	
+
 	        setCss('background:url(https://),url(https://),red url(https://)');
-	
+
 	        // If the UA supports multiple backgrounds, there should be three occurrences
 	        //   of the string "url(" in the return value for elemStyle.background
-	
+
 	        return (/(url\s*\(.*?){3}/).test(mStyle.background);
 	    };
-	
-	
-	
+
+
+
 	    // this will false positive in Opera Mini
 	    //   github.com/Modernizr/Modernizr/issues/396
-	
+
 	    tests['backgroundsize'] = function() {
 	        return testPropsAll('backgroundSize');
 	    };
-	
+
 	    tests['borderimage'] = function() {
 	        return testPropsAll('borderImage');
 	    };
-	
-	
+
+
 	    // Super comprehensive table about all the unique implementations of
 	    // border-radius: muddledramblings.com/table-of-css3-border-radius-compliance
-	
+
 	    tests['borderradius'] = function() {
 	        return testPropsAll('borderRadius');
 	    };
-	
+
 	    // WebOS unfortunately false positives on this test.
 	    tests['boxshadow'] = function() {
 	        return testPropsAll('boxShadow');
 	    };
-	
+
 	    // FF3.0 will false positive on this test
 	    tests['textshadow'] = function() {
 	        return document.createElement('div').style.textShadow === '';
 	    };
-	
-	
+
+
 	    tests['opacity'] = function() {
 	        // Browsers that actually have CSS Opacity implemented have done so
 	        //  according to spec, which means their return values are within the
 	        //  range of [0.0,1.0] - including the leading zero.
-	
+
 	        setCssAll('opacity:.55');
-	
+
 	        // The non-literal . in this regex is intentional:
 	        //   German Chrome returns this value as 0,55
 	        // github.com/Modernizr/Modernizr/issues/#issue/59/comment/516632
 	        return (/^0.55$/).test(mStyle.opacity);
 	    };
-	
-	
+
+
 	    // Note, Android < 4 will pass this test, but can only animate
 	    //   a single property at a time
 	    //   daneden.me/2011/12/putting-up-with-androids-bullshit/
 	    tests['cssanimations'] = function() {
 	        return testPropsAll('animationName');
 	    };
-	
-	
+
+
 	    tests['csscolumns'] = function() {
 	        return testPropsAll('columnCount');
 	    };
-	
-	
+
+
 	    tests['cssgradients'] = function() {
 	        /**
 	         * For CSS Gradients syntax, please see:
@@ -766,42 +768,42 @@
 	         * developer.mozilla.org/en/CSS/-moz-radial-gradient
 	         * dev.w3.org/csswg/css3-images/#gradients-
 	         */
-	
+
 	        var str1 = 'background-image:',
 	            str2 = 'gradient(linear,left top,right bottom,from(#9f9),to(white));',
 	            str3 = 'linear-gradient(left top,#9f9, white);';
-	
+
 	        setCss(
 	             // legacy webkit syntax (FIXME: remove when syntax not in use anymore)
 	              (str1 + '-webkit- '.split(' ').join(str2 + str1) +
 	             // standard syntax             // trailing 'background-image:'
 	              prefixes.join(str3 + str1)).slice(0, -str1.length)
 	        );
-	
+
 	        return contains(mStyle.backgroundImage, 'gradient');
 	    };
-	
-	
+
+
 	    tests['cssreflections'] = function() {
 	        return testPropsAll('boxReflect');
 	    };
-	
-	
+
+
 	    tests['csstransforms'] = function() {
 	        return !!testPropsAll('transform');
 	    };
-	
-	
+
+
 	    tests['csstransforms3d'] = function() {
-	
+
 	        var ret = !!testPropsAll('perspective');
-	
+
 	        // Webkit's 3D transforms are passed off to the browser's own graphics renderer.
 	        //   It works fine in Safari on Leopard and Snow Leopard, but not in Chrome in
 	        //   some conditions. As a result, Webkit typically recognizes the syntax but
 	        //   will sometimes throw a false positive, thus we must do a more thorough check:
 	        if ( ret && 'webkitPerspective' in docElement.style ) {
-	
+
 	          // Webkit allows this media query to succeed only if the feature is enabled.
 	          // `@media (transform-3d),(-webkit-transform-3d){ ... }`
 	          injectElementWithStyles('@media (transform-3d),(-webkit-transform-3d){#modernizr{left:9px;position:absolute;height:3px;}}', function( node, rule ) {
@@ -810,48 +812,48 @@
 	        }
 	        return ret;
 	    };
-	
-	
+
+
 	    tests['csstransitions'] = function() {
 	        return testPropsAll('transition');
 	    };
-	
-	
+
+
 	    /*>>fontface*/
 	    // @font-face detection routine by Diego Perini
 	    // javascript.nwbox.com/CSSSupport/
-	
+
 	    // false positives:
 	    //   WebOS github.com/Modernizr/Modernizr/issues/342
 	    //   WP7   github.com/Modernizr/Modernizr/issues/538
 	    tests['fontface'] = function() {
 	        var bool;
-	
+
 	        injectElementWithStyles('@font-face {font-family:"font";src:url("https://")}', function( node, rule ) {
 	          var style = document.getElementById('smodernizr'),
 	              sheet = style.sheet || style.styleSheet,
 	              cssText = sheet ? (sheet.cssRules && sheet.cssRules[0] ? sheet.cssRules[0].cssText : sheet.cssText || '') : '';
-	
+
 	          bool = /src/i.test(cssText) && cssText.indexOf(rule.split(' ')[0]) === 0;
 	        });
-	
+
 	        return bool;
 	    };
 	    /*>>fontface*/
-	
+
 	    // CSS generated content detection
 	    tests['generatedcontent'] = function() {
 	        var bool;
-	
+
 	        injectElementWithStyles(['#',mod,'{font:0/0 a}#',mod,':after{content:"',smile,'";visibility:hidden;font:3px/1 a}'].join(''), function( node ) {
 	          bool = node.offsetHeight >= 3;
 	        });
-	
+
 	        return bool;
 	    };
-	
-	
-	
+
+
+
 	    // These tests evaluate support of the video/audio elements, as well as
 	    // testing what types of content they support.
 	    //
@@ -861,42 +863,42 @@
 	    //
 	    // Codec values from : github.com/NielsLeenheer/html5test/blob/9106a8/index.html#L845
 	    //                     thx to NielsLeenheer and zcorpan
-	
+
 	    // Note: in some older browsers, "no" was a return value instead of empty string.
 	    //   It was live in FF3.5.0 and 3.5.1, but fixed in 3.5.2
 	    //   It was also live in Safari 4.0.0 - 4.0.4, but fixed in 4.0.5
-	
+
 	    tests['video'] = function() {
 	        var elem = document.createElement('video'),
 	            bool = false;
-	
+
 	        // IE9 Running on Windows Server SKU can cause an exception to be thrown, bug #224
 	        try {
 	            if ( bool = !!elem.canPlayType ) {
 	                bool      = new Boolean(bool);
 	                bool.ogg  = elem.canPlayType('video/ogg; codecs="theora"')      .replace(/^no$/,'');
-	
+
 	                // Without QuickTime, this value will be `undefined`. github.com/Modernizr/Modernizr/issues/546
 	                bool.h264 = elem.canPlayType('video/mp4; codecs="avc1.42E01E"') .replace(/^no$/,'');
-	
+
 	                bool.webm = elem.canPlayType('video/webm; codecs="vp8, vorbis"').replace(/^no$/,'');
 	            }
-	
+
 	        } catch(e) { }
-	
+
 	        return bool;
 	    };
-	
+
 	    tests['audio'] = function() {
 	        var elem = document.createElement('audio'),
 	            bool = false;
-	
+
 	        try {
 	            if ( bool = !!elem.canPlayType ) {
 	                bool      = new Boolean(bool);
 	                bool.ogg  = elem.canPlayType('audio/ogg; codecs="vorbis"').replace(/^no$/,'');
 	                bool.mp3  = elem.canPlayType('audio/mpeg;')               .replace(/^no$/,'');
-	
+
 	                // Mimetypes accepted:
 	                //   developer.mozilla.org/En/Media_formats_supported_by_the_audio_and_video_elements
 	                //   bit.ly/iphoneoscodecs
@@ -905,28 +907,28 @@
 	                              elem.canPlayType('audio/aac;'))             .replace(/^no$/,'');
 	            }
 	        } catch(e) { }
-	
+
 	        return bool;
 	    };
-	
-	
+
+
 	    // In FF4, if disabled, window.localStorage should === null.
-	
+
 	    // Normally, we could not test that directly and need to do a
 	    //   `('localStorage' in window) && ` test first because otherwise Firefox will
 	    //   throw bugzil.la/365772 if cookies are disabled
-	
+
 	    // Also in iOS5 Private Browsing mode, attempting to use localStorage.setItem
 	    // will throw the exception:
 	    //   QUOTA_EXCEEDED_ERRROR DOM Exception 22.
 	    // Peculiarly, getItem and removeItem calls do not throw.
-	
+
 	    // Because we are forced to try/catch this, we'll go aggressive.
-	
+
 	    // Just FWIW: IE8 Compat mode supports these features completely:
 	    //   www.quirksmode.org/dom/html5.html
 	    // But IE8 doesn't support either with local files
-	
+
 	    tests['localstorage'] = function() {
 	        try {
 	            localStorage.setItem(mod, mod);
@@ -936,7 +938,7 @@
 	            return false;
 	        }
 	    };
-	
+
 	    tests['sessionstorage'] = function() {
 	        try {
 	            sessionStorage.setItem(mod, mod);
@@ -946,23 +948,23 @@
 	            return false;
 	        }
 	    };
-	
-	
+
+
 	    tests['webworkers'] = function() {
 	        return !!window.Worker;
 	    };
-	
-	
+
+
 	    tests['applicationcache'] = function() {
 	        return !!window.applicationCache;
 	    };
-	
-	
+
+
 	    // Thanks to Erik Dahlstrom
 	    tests['svg'] = function() {
 	        return !!document.createElementNS && !!document.createElementNS(ns.svg, 'svg').createSVGRect;
 	    };
-	
+
 	    // specifically for SVG inline in HTML, not within XHTML
 	    // test page: paulirish.com/demo/inline-svg
 	    tests['inlinesvg'] = function() {
@@ -970,21 +972,21 @@
 	      div.innerHTML = '<svg/>';
 	      return (div.firstChild && div.firstChild.namespaceURI) == ns.svg;
 	    };
-	
+
 	    // SVG SMIL animation
 	    tests['smil'] = function() {
 	        return !!document.createElementNS && /SVGAnimate/.test(toString.call(document.createElementNS(ns.svg, 'animate')));
 	    };
-	
+
 	    // This test is only for clip paths in SVG proper, not clip paths on HTML content
 	    // demo: srufaculty.sru.edu/david.dailey/svg/newstuff/clipPath4.svg
-	
+
 	    // However read the comments to dig into applying SVG clippaths to HTML content here:
 	    //   github.com/Modernizr/Modernizr/issues/213#issuecomment-1149491
 	    tests['svgclippaths'] = function() {
 	        return !!document.createElementNS && /SVGClipPath/.test(toString.call(document.createElementNS(ns.svg, 'clipPath')));
 	    };
-	
+
 	    /*>>webforms*/
 	    // input features and input types go directly onto the ret object, bypassing the tests loop.
 	    // Hold this guy to execute in a moment.
@@ -996,7 +998,7 @@
 	        //   when applied to all input types:
 	        //   miketaylr.com/code/input-type-attr.html
 	        // spec: www.whatwg.org/specs/web-apps/current-work/multipage/the-input-element.html#input-type-attr-summary
-	
+
 	        // Only input placeholder is tested while textarea's placeholder is not.
 	        // Currently Safari 4 and Opera 11 have support only for the input placeholder
 	        // Both tests are available in feature-detects/forms-placeholder.js
@@ -1012,60 +1014,60 @@
 	            return attrs;
 	        })('autocomplete autofocus list placeholder max min multiple pattern required step'.split(' '));
 	        /*>>input*/
-	
+
 	        /*>>inputtypes*/
 	        // Run through HTML5's new input types to see if the UA understands any.
 	        //   This is put behind the tests runloop because it doesn't return a
 	        //   true/false like all the other tests; instead, it returns an object
 	        //   containing each input type with its corresponding true/false value
-	
+
 	        // Big thanks to @miketaylr for the html5 forms expertise. miketaylr.com/
 	        Modernizr['inputtypes'] = (function(props) {
-	
+
 	            for ( var i = 0, bool, inputElemType, defaultView, len = props.length; i < len; i++ ) {
-	
+
 	                inputElem.setAttribute('type', inputElemType = props[i]);
 	                bool = inputElem.type !== 'text';
-	
+
 	                // We first check to see if the type we give it sticks..
 	                // If the type does, we feed it a textual value, which shouldn't be valid.
 	                // If the value doesn't stick, we know there's input sanitization which infers a custom UI
 	                if ( bool ) {
-	
+
 	                    inputElem.value         = smile;
 	                    inputElem.style.cssText = 'position:absolute;visibility:hidden;';
-	
+
 	                    if ( /^range$/.test(inputElemType) && inputElem.style.WebkitAppearance !== undefined ) {
-	
+
 	                      docElement.appendChild(inputElem);
 	                      defaultView = document.defaultView;
-	
+
 	                      // Safari 2-4 allows the smiley as a value, despite making a slider
 	                      bool =  defaultView.getComputedStyle &&
 	                              defaultView.getComputedStyle(inputElem, null).WebkitAppearance !== 'textfield' &&
 	                              // Mobile android web browser has false positive, so must
 	                              // check the height to see if the widget is actually there.
 	                              (inputElem.offsetHeight !== 0);
-	
+
 	                      docElement.removeChild(inputElem);
-	
+
 	                    } else if ( /^(search|tel)$/.test(inputElemType) ){
 	                      // Spec doesn't define any special parsing or detectable UI
 	                      //   behaviors so we pass these through as true
-	
+
 	                      // Interestingly, opera fails the earlier test, so it doesn't
 	                      //  even make it here.
-	
+
 	                    } else if ( /^(url|email)$/.test(inputElemType) ) {
 	                      // Real url and email support comes with prebaked validation.
 	                      bool = inputElem.checkValidity && inputElem.checkValidity() === false;
-	
+
 	                    } else {
 	                      // If the upgraded input compontent rejects the :) text, we got a winner
 	                      bool = inputElem.value != smile;
 	                    }
 	                }
-	
+
 	                inputs[ props[i] ] = !!bool;
 	            }
 	            return inputs;
@@ -1073,13 +1075,13 @@
 	        /*>>inputtypes*/
 	    }
 	    /*>>webforms*/
-	
-	
+
+
 	    // End of test definitions
 	    // -----------------------
-	
-	
-	
+
+
+
 	    // Run through all tests and detect their support in the current UA.
 	    // todo: hypothetically we could be doing an array of tests and use a basic loop here.
 	    for ( var feature in tests ) {
@@ -1089,17 +1091,17 @@
 	            //   and push it into an array of classes we'll join later.
 	            featureName  = feature.toLowerCase();
 	            Modernizr[featureName] = tests[feature]();
-	
+
 	            classes.push((Modernizr[featureName] ? '' : 'no-') + featureName);
 	        }
 	    }
-	
+
 	    /*>>webforms*/
 	    // input tests need to run.
 	    Modernizr.input || webforms();
 	    /*>>webforms*/
-	
-	
+
+
 	    /**
 	     * addTest allows the user to define their own feature tests
 	     * the result will be added onto the Modernizr object,
@@ -1116,9 +1118,9 @@
 	           }
 	         }
 	       } else {
-	
+
 	         feature = feature.toLowerCase();
-	
+
 	         if ( Modernizr[feature] !== undefined ) {
 	           // we're going to quit if you're trying to overwrite an existing test
 	           // if we were to allow it, we'd do this:
@@ -1127,59 +1129,59 @@
 	           // but, no rly, stuff 'em.
 	           return Modernizr;
 	         }
-	
+
 	         test = typeof test == 'function' ? test() : test;
-	
+
 	         if (typeof enableClasses !== "undefined" && enableClasses) {
 	           docElement.className += ' ' + (test ? '' : 'no-') + feature;
 	         }
 	         Modernizr[feature] = test;
-	
+
 	       }
-	
+
 	       return Modernizr; // allow chaining.
 	     };
-	
-	
+
+
 	    // Reset modElem.cssText to nothing to reduce memory footprint.
 	    setCss('');
 	    modElem = inputElem = null;
-	
+
 	    /*>>shiv*/
 	    /*! HTML5 Shiv v3.6.1 | @afarkas @jdalton @jon_neal @rem | MIT/GPL2 Licensed */
 	    ;(function(window, document) {
 	    /*jshint evil:true */
 	      /** Preset options */
 	      var options = window.html5 || {};
-	
+
 	      /** Used to skip problem elements */
 	      var reSkip = /^<|^(?:button|map|select|textarea|object|iframe|option|optgroup)$/i;
-	
+
 	      /** Not all elements can be cloned in IE **/
 	      var saveClones = /^(?:a|b|code|div|fieldset|h1|h2|h3|h4|h5|h6|i|label|li|ol|p|q|span|strong|style|table|tbody|td|th|tr|ul)$/i;
-	
+
 	      /** Detect whether the browser supports default html5 styles */
 	      var supportsHtml5Styles;
-	
+
 	      /** Name of the expando, to work with multiple documents or to re-shiv one document */
 	      var expando = '_html5shiv';
-	
+
 	      /** The id for the the documents expando */
 	      var expanID = 0;
-	
+
 	      /** Cached data for each document */
 	      var expandoData = {};
-	
+
 	      /** Detect whether the browser supports unknown elements */
 	      var supportsUnknownElements;
-	
+
 	      (function() {
 	        try {
 	            var a = document.createElement('a');
 	            a.innerHTML = '<xyz></xyz>';
 	            //if the hidden property is implemented we can assume, that the browser supports basic HTML5 Styles
 	            supportsHtml5Styles = ('hidden' in a);
-	
+
 	            supportsUnknownElements = a.childNodes.length == 1 || (function() {
 	              // assign a false positive if unable to shiv
 	              (document.createElement)('a');
@@ -1194,11 +1196,11 @@
 	          supportsHtml5Styles = true;
 	          supportsUnknownElements = true;
 	        }
-	
+
 	      }());
-	
+
 	      /*--------------------------------------------------------------------------*/
-	
+
 	      /**
 	       * Creates a style sheet with the given CSS text and adds it to the document.
 	       * @private
@@ -1209,11 +1211,11 @@
 	      function addStyleSheet(ownerDocument, cssText) {
 	        var p = ownerDocument.createElement('p'),
 	            parent = ownerDocument.getElementsByTagName('head')[0] || ownerDocument.documentElement;
-	
+
 	        p.innerHTML = 'x<style>' + cssText + '</style>';
 	        return parent.insertBefore(p.lastChild, parent.firstChild);
 	      }
-	
+
 	      /**
 	       * Returns the value of `html5.elements` as an array.
 	       * @private
@@ -1223,7 +1225,7 @@
 	        var elements = html5.elements;
 	        return typeof elements == 'string' ? elements.split(' ') : elements;
 	      }
-	
+
 	        /**
 	       * Returns the data associated to the given document
 	       * @private
@@ -1240,7 +1242,7 @@
 	        }
 	        return data;
 	      }
-	
+
 	      /**
 	       * returns a shived element for the given nodeName and document
 	       * @memberOf html5
@@ -1259,7 +1261,7 @@
 	            data = getExpandoData(ownerDocument);
 	        }
 	        var node;
-	
+
 	        if (data.cache[nodeName]) {
 	            node = data.cache[nodeName].cloneNode();
 	        } else if (saveClones.test(nodeName)) {
@@ -1267,7 +1269,7 @@
 	        } else {
 	            node = data.createElem(nodeName);
 	        }
-	
+
 	        // Avoid adding some elements to fragments in IE < 9 because
 	        // * Attributes like `name` or `type` cannot be set/changed once an element
 	        //   is inserted into a document/fragment
@@ -1277,7 +1279,7 @@
 	        //   or `text` property is set
 	        return node.canHaveChildren && !reSkip.test(nodeName) ? data.frag.appendChild(node) : node;
 	      }
-	
+
 	      /**
 	       * returns a shived DocumentFragment for the given document
 	       * @memberOf html5
@@ -1301,7 +1303,7 @@
 	        }
 	        return clone;
 	      }
-	
+
 	      /**
 	       * Shivs the `createElement` and `createDocumentFragment` methods of the document.
 	       * @private
@@ -1315,8 +1317,8 @@
 	            data.createFrag = ownerDocument.createDocumentFragment;
 	            data.frag = data.createFrag();
 	        }
-	
-	
+
+
 	        ownerDocument.createElement = function(nodeName) {
 	          //abort shiv
 	          if (!html5.shivMethods) {
@@ -1324,7 +1326,7 @@
 	          }
 	          return createElement(nodeName, ownerDocument, data);
 	        };
-	
+
 	        ownerDocument.createDocumentFragment = Function('h,f', 'return function(){' +
 	          'var n=f.cloneNode(),c=n.createElement;' +
 	          'h.shivMethods&&(' +
@@ -1337,9 +1339,9 @@
 	          ');return n}'
 	        )(html5, data.frag);
 	      }
-	
+
 	      /*--------------------------------------------------------------------------*/
-	
+
 	      /**
 	       * Shivs the given document.
 	       * @memberOf html5
@@ -1351,7 +1353,7 @@
 	            ownerDocument = document;
 	        }
 	        var data = getExpandoData(ownerDocument);
-	
+
 	        if (html5.shivCSS && !supportsHtml5Styles && !data.hasCSS) {
 	          data.hasCSS = !!addStyleSheet(ownerDocument,
 	            // corrects block display not defined in IE6/7/8/9
@@ -1365,9 +1367,9 @@
 	        }
 	        return ownerDocument;
 	      }
-	
+
 	      /*--------------------------------------------------------------------------*/
-	
+
 	      /**
 	       * The `html5` object is exposed so that more elements can be shived and
 	       * existing shiving can be detected on iframes.
@@ -1378,28 +1380,28 @@
 	       * html5 = { 'elements': 'mark section', 'shivCSS': false, 'shivMethods': false };
 	       */
 	      var html5 = {
-	
+
 	        /**
 	         * An array or space separated string of node names of the elements to shiv.
 	         * @memberOf html5
 	         * @type Array|String
 	         */
 	        'elements': options.elements || 'abbr article aside audio bdi canvas data datalist details figcaption figure footer header hgroup mark meter nav output progress section summary time video',
-	
+
 	        /**
 	         * A flag to indicate that the HTML5 style sheet should be inserted.
 	         * @memberOf html5
 	         * @type Boolean
 	         */
 	        'shivCSS': (options.shivCSS !== false),
-	
+
 	        /**
 	         * Is equal to true if a browser supports creating unknown/HTML5 elements
 	         * @memberOf html5
 	         * @type boolean
 	         */
 	        'supportsUnknownElements': supportsUnknownElements,
-	
+
 	        /**
 	         * A flag to indicate that the document's `createElement` and `createDocumentFragment`
 	         * methods should be overwritten.
@@ -1407,38 +1409,38 @@
 	         * @type Boolean
 	         */
 	        'shivMethods': (options.shivMethods !== false),
-	
+
 	        /**
 	         * A string to describe the type of `html5` object ("default" or "default print").
 	         * @memberOf html5
 	         * @type String
 	         */
 	        'type': 'default',
-	
+
 	        // shivs the document according to the specified `html5` object options
 	        'shivDocument': shivDocument,
-	
+
 	        //creates a shived element
 	        createElement: createElement,
-	
+
 	        //creates a shived documentFragment
 	        createDocumentFragment: createDocumentFragment
 	      };
-	
+
 	      /*--------------------------------------------------------------------------*/
-	
+
 	      // expose html5
 	      window.html5 = html5;
-	
+
 	      // shiv the document
 	      shivDocument(document);
-	
+
 	    }(this, document));
 	    /*>>shiv*/
-	
+
 	    // Assign private properties to the return object with prefix
 	    Modernizr._version      = version;
-	
+
 	    // expose these for the plugin API. Look in the source for how to join() them against your input
 	    /*>>prefixes*/
 	    Modernizr._prefixes     = prefixes;
@@ -1447,7 +1449,7 @@
 	    Modernizr._domPrefixes  = domPrefixes;
 	    Modernizr._cssomPrefixes  = cssomPrefixes;
 	    /*>>domprefixes*/
-	
+
 	    /*>>mq*/
 	    // Modernizr.mq tests a given media query, live against the current state of the window
 	    // A few important notes:
@@ -1459,13 +1461,13 @@
 	    // Modernizr.mq('only screen and (max-width:768)')
 	    Modernizr.mq            = testMediaQuery;
 	    /*>>mq*/
-	
+
 	    /*>>hasevent*/
 	    // Modernizr.hasEvent() detects support for a given event, with an optional element to test on
 	    // Modernizr.hasEvent('gesturestart', elem)
 	    Modernizr.hasEvent      = isEventSupported;
 	    /*>>hasevent*/
-	
+
 	    /*>>testprop*/
 	    // Modernizr.testProp() investigates whether a given style property is recognized
 	    // Note that the property names must be provided in the camelCase variant.
@@ -1474,7 +1476,7 @@
 	        return testProps([prop]);
 	    };
 	    /*>>testprop*/
-	
+
 	    /*>>testallprops*/
 	    // Modernizr.testAllProps() investigates whether a given style property,
 	    //   or any of its vendor-prefixed variants, is recognized
@@ -1482,24 +1484,24 @@
 	    // Modernizr.testAllProps('boxSizing')
 	    Modernizr.testAllProps  = testPropsAll;
 	    /*>>testallprops*/
-	
-	
+
+
 	    /*>>teststyles*/
 	    // Modernizr.testStyles() allows you to add custom styles to the document and test an element afterwards
 	    // Modernizr.testStyles('#modernizr { position:absolute }', function(elem, rule){ ... })
 	    Modernizr.testStyles    = injectElementWithStyles;
 	    /*>>teststyles*/
-	
-	
+
+
 	    /*>>prefixed*/
 	    // Modernizr.prefixed() returns the prefixed or nonprefixed property name variant of your input
 	    // Modernizr.prefixed('boxSizing') // 'MozBoxSizing'
-	
+
 	    // Properties must be passed as dom-style camelcase, rather than `box-sizing` hypentated style.
 	    // Return values will also be the camelCase variant, if you need to translate that to hypenated style use:
 	    //
 	    //     str.replace(/([A-Z])/g, function(str,m1){ return '-' + m1.toLowerCase(); }).replace(/^ms-/,'-ms-');
-	
+
 	    // If you're trying to ascertain which transition end event to bind to, you might do something like...
 	    //
 	    //     var transEndEventNames = {
@@ -1510,7 +1512,7 @@
 	    //       'transition'       : 'transitionend'
 	    //     },
 	    //     transEndEventName = transEndEventNames[ Modernizr.prefixed('transition') ];
-	
+
 	    Modernizr.prefixed      = function(prop, obj, elem){
 	      if(!obj) {
 	        return testPropsAll(prop, 'pfx');
@@ -1520,27 +1522,26 @@
 	      }
 	    };
 	    /*>>prefixed*/
-	
-	
+
+
 	    /*>>cssclasses*/
 	    // Remove "no-js" class from <html> element, if it exists:
 	    docElement.className = docElement.className.replace(/(^|\s)no-js(\s|$)/, '$1$2') +
-	
+
 	                            // Add the new classes to the <html> element.
 	                            (enableClasses ? ' js ' + classes.join(' ') : '');
 	    /*>>cssclasses*/
-	
+
 	    return Modernizr;
-	
+
 	})(this, this.document);
-	
+
 
 /***/ },
-
-/***/ 2:
+/* 2 */
 /***/ function(module, exports, require) {
 
-	/* WEBPACK VAR INJECTION */(function(require, module) {/*!
+	/* WEBPACK VAR INJECTION */(function(require, module) {var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 	 * jQuery JavaScript Library v2.0.3
 	 * http://jquery.com/
 	 *
@@ -1554,7 +1555,7 @@
 	 * Date: 2013-07-03T13:30Z
 	 */
 	(function( window, undefined ) {
-	
+
 	// Can't do this because several apps including ASP.NET trace
 	// the stack via arguments.caller.callee and Firefox dies if
 	// you try to trace through "use strict" call chains. (#13335)
@@ -1563,33 +1564,33 @@
 	var
 		// A central reference to the root jQuery(document)
 		rootjQuery,
-	
+
 		// The deferred used on DOM ready
 		readyList,
-	
+
 		// Support: IE9
 		// For `typeof xmlNode.method` instead of `xmlNode.method !== undefined`
 		core_strundefined = typeof undefined,
-	
+
 		// Use the correct document accordingly with window argument (sandbox)
 		location = window.location,
 		document = window.document,
 		docElem = document.documentElement,
-	
+
 		// Map over jQuery in case of overwrite
 		_jQuery = window.jQuery,
-	
+
 		// Map over the $ in case of overwrite
 		_$ = window.$,
-	
+
 		// [[Class]] -> type pairs
 		class2type = {},
-	
+
 		// List of deleted data cache ids, so we can reuse them
 		core_deletedIds = [],
-	
+
 		core_version = "2.0.3",
-	
+
 		// Save a reference to some core methods
 		core_concat = core_deletedIds.concat,
 		core_push = core_deletedIds.push,
@@ -1598,100 +1599,100 @@
 		core_toString = class2type.toString,
 		core_hasOwn = class2type.hasOwnProperty,
 		core_trim = core_version.trim,
-	
+
 		// Define a local copy of jQuery
 		jQuery = function( selector, context ) {
 			// The jQuery object is actually just the init constructor 'enhanced'
 			return new jQuery.fn.init( selector, context, rootjQuery );
 		},
-	
+
 		// Used for matching numbers
 		core_pnum = /[+-]?(?:\d*\.|)\d+(?:[eE][+-]?\d+|)/.source,
-	
+
 		// Used for splitting on whitespace
 		core_rnotwhite = /\S+/g,
-	
+
 		// A simple way to check for HTML strings
 		// Prioritize #id over <tag> to avoid XSS via location.hash (#9521)
 		// Strict HTML recognition (#11290: must start with <)
 		rquickExpr = /^(?:\s*(<[\w\W]+>)[^>]*|#([\w-]*))$/,
-	
+
 		// Match a standalone tag
 		rsingleTag = /^<(\w+)\s*\/?>(?:<\/\1>|)$/,
-	
+
 		// Matches dashed string for camelizing
 		rmsPrefix = /^-ms-/,
 		rdashAlpha = /-([\da-z])/gi,
-	
+
 		// Used by jQuery.camelCase as callback to replace()
 		fcamelCase = function( all, letter ) {
 			return letter.toUpperCase();
 		},
-	
+
 		// The ready event handler and self cleanup method
 		completed = function() {
 			document.removeEventListener( "DOMContentLoaded", completed, false );
 			window.removeEventListener( "load", completed, false );
 			jQuery.ready();
 		};
-	
+
 	jQuery.fn = jQuery.prototype = {
 		// The current version of jQuery being used
 		jquery: core_version,
-	
+
 		constructor: jQuery,
 		init: function( selector, context, rootjQuery ) {
 			var match, elem;
-	
+
 			// HANDLE: $(""), $(null), $(undefined), $(false)
 			if ( !selector ) {
 				return this;
 			}
-	
+
 			// Handle HTML strings
 			if ( typeof selector === "string" ) {
 				if ( selector.charAt(0) === "<" && selector.charAt( selector.length - 1 ) === ">" && selector.length >= 3 ) {
 					// Assume that strings that start and end with <> are HTML and skip the regex check
 					match = [ null, selector, null ];
-	
+
 				} else {
 					match = rquickExpr.exec( selector );
 				}
-	
+
 				// Match html or make sure no context is specified for #id
 				if ( match && (match[1] || !context) ) {
-	
+
 					// HANDLE: $(html) -> $(array)
 					if ( match[1] ) {
 						context = context instanceof jQuery ? context[0] : context;
-	
+
 						// scripts is true for back-compat
 						jQuery.merge( this, jQuery.parseHTML(
 							match[1],
 							context && context.nodeType ? context.ownerDocument || context : document,
 							true
 						) );
-	
+
 						// HANDLE: $(html, props)
 						if ( rsingleTag.test( match[1] ) && jQuery.isPlainObject( context ) ) {
 							for ( match in context ) {
 								// Properties of context are called as methods if possible
 								if ( jQuery.isFunction( this[ match ] ) ) {
 									this[ match ]( context[ match ] );
-	
+
 								// ...and otherwise set as attributes
 								} else {
 									this.attr( match, context[ match ] );
 								}
 							}
 						}
-	
+
 						return this;
-	
+
 					// HANDLE: $(#id)
 					} else {
 						elem = document.getElementById( match[2] );
-	
+
 						// Check parentNode to catch when Blackberry 4.6 returns
 						// nodes that are no longer in the document #6963
 						if ( elem && elem.parentNode ) {
@@ -1699,138 +1700,138 @@
 							this.length = 1;
 							this[0] = elem;
 						}
-	
+
 						this.context = document;
 						this.selector = selector;
 						return this;
 					}
-	
+
 				// HANDLE: $(expr, $(...))
 				} else if ( !context || context.jquery ) {
 					return ( context || rootjQuery ).find( selector );
-	
+
 				// HANDLE: $(expr, context)
 				// (which is just equivalent to: $(context).find(expr)
 				} else {
 					return this.constructor( context ).find( selector );
 				}
-	
+
 			// HANDLE: $(DOMElement)
 			} else if ( selector.nodeType ) {
 				this.context = this[0] = selector;
 				this.length = 1;
 				return this;
-	
+
 			// HANDLE: $(function)
 			// Shortcut for document ready
 			} else if ( jQuery.isFunction( selector ) ) {
 				return rootjQuery.ready( selector );
 			}
-	
+
 			if ( selector.selector !== undefined ) {
 				this.selector = selector.selector;
 				this.context = selector.context;
 			}
-	
+
 			return jQuery.makeArray( selector, this );
 		},
-	
+
 		// Start with an empty selector
 		selector: "",
-	
+
 		// The default length of a jQuery object is 0
 		length: 0,
-	
+
 		toArray: function() {
 			return core_slice.call( this );
 		},
-	
+
 		// Get the Nth element in the matched element set OR
 		// Get the whole matched element set as a clean array
 		get: function( num ) {
 			return num == null ?
-	
+
 				// Return a 'clean' array
 				this.toArray() :
-	
+
 				// Return just the object
 				( num < 0 ? this[ this.length + num ] : this[ num ] );
 		},
-	
+
 		// Take an array of elements and push it onto the stack
 		// (returning the new matched element set)
 		pushStack: function( elems ) {
-	
+
 			// Build a new jQuery matched element set
 			var ret = jQuery.merge( this.constructor(), elems );
-	
+
 			// Add the old object onto the stack (as a reference)
 			ret.prevObject = this;
 			ret.context = this.context;
-	
+
 			// Return the newly-formed element set
 			return ret;
 		},
-	
+
 		// Execute a callback for every element in the matched set.
 		// (You can seed the arguments with an array of args, but this is
 		// only used internally.)
 		each: function( callback, args ) {
 			return jQuery.each( this, callback, args );
 		},
-	
+
 		ready: function( fn ) {
 			// Add the callback
 			jQuery.ready.promise().done( fn );
-	
+
 			return this;
 		},
-	
+
 		slice: function() {
 			return this.pushStack( core_slice.apply( this, arguments ) );
 		},
-	
+
 		first: function() {
 			return this.eq( 0 );
 		},
-	
+
 		last: function() {
 			return this.eq( -1 );
 		},
-	
+
 		eq: function( i ) {
 			var len = this.length,
 				j = +i + ( i < 0 ? len : 0 );
 			return this.pushStack( j >= 0 && j < len ? [ this[j] ] : [] );
 		},
-	
+
 		map: function( callback ) {
 			return this.pushStack( jQuery.map(this, function( elem, i ) {
 				return callback.call( elem, i, elem );
 			}));
 		},
-	
+
 		end: function() {
 			return this.prevObject || this.constructor(null);
 		},
-	
+
 		// For internal use only.
 		// Behaves like an Array's method, not like a jQuery method.
 		push: core_push,
 		sort: [].sort,
 		splice: [].splice
 	};
-	
+
 	// Give the init function the jQuery prototype for later instantiation
 	jQuery.fn.init.prototype = jQuery.fn;
-	
+
 	jQuery.extend = jQuery.fn.extend = function() {
 		var options, name, src, copy, copyIsArray, clone,
 			target = arguments[0] || {},
 			i = 1,
 			length = arguments.length,
 			deep = false;
-	
+
 		// Handle a deep copy situation
 		if ( typeof target === "boolean" ) {
 			deep = target;
@@ -1838,18 +1839,18 @@
 			// skip the boolean and the target
 			i = 2;
 		}
-	
+
 		// Handle case when target is a string or something (possible in deep copy)
 		if ( typeof target !== "object" && !jQuery.isFunction(target) ) {
 			target = {};
 		}
-	
+
 		// extend jQuery itself if only one argument is passed
 		if ( length === i ) {
 			target = this;
 			--i;
 		}
-	
+
 		for ( ; i < length; i++ ) {
 			// Only deal with non-null/undefined values
 			if ( (options = arguments[ i ]) != null ) {
@@ -1857,25 +1858,25 @@
 				for ( name in options ) {
 					src = target[ name ];
 					copy = options[ name ];
-	
+
 					// Prevent never-ending loop
 					if ( target === copy ) {
 						continue;
 					}
-	
+
 					// Recurse if we're merging plain objects or arrays
 					if ( deep && copy && ( jQuery.isPlainObject(copy) || (copyIsArray = jQuery.isArray(copy)) ) ) {
 						if ( copyIsArray ) {
 							copyIsArray = false;
 							clone = src && jQuery.isArray(src) ? src : [];
-	
+
 						} else {
 							clone = src && jQuery.isPlainObject(src) ? src : {};
 						}
-	
+
 						// Never move original objects, clone them
 						target[ name ] = jQuery.extend( deep, clone, copy );
-	
+
 					// Don't bring in undefined values
 					} else if ( copy !== undefined ) {
 						target[ name ] = copy;
@@ -1883,34 +1884,34 @@
 				}
 			}
 		}
-	
+
 		// Return the modified object
 		return target;
 	};
-	
+
 	jQuery.extend({
 		// Unique for each copy of jQuery on the page
 		expando: "jQuery" + ( core_version + Math.random() ).replace( /\D/g, "" ),
-	
+
 		noConflict: function( deep ) {
 			if ( window.$ === jQuery ) {
 				window.$ = _$;
 			}
-	
+
 			if ( deep && window.jQuery === jQuery ) {
 				window.jQuery = _jQuery;
 			}
-	
+
 			return jQuery;
 		},
-	
+
 		// Is the DOM ready to be used? Set to true once it occurs.
 		isReady: false,
-	
+
 		// A counter to track how many items to wait for before
 		// the ready event fires. See #6781
 		readyWait: 1,
-	
+
 		// Hold (or release) the ready event
 		holdReady: function( hold ) {
 			if ( hold ) {
@@ -1919,49 +1920,49 @@
 				jQuery.ready( true );
 			}
 		},
-	
+
 		// Handle when the DOM is ready
 		ready: function( wait ) {
-	
+
 			// Abort if there are pending holds or we're already ready
 			if ( wait === true ? --jQuery.readyWait : jQuery.isReady ) {
 				return;
 			}
-	
+
 			// Remember that the DOM is ready
 			jQuery.isReady = true;
-	
+
 			// If a normal DOM Ready event fired, decrement, and wait if need be
 			if ( wait !== true && --jQuery.readyWait > 0 ) {
 				return;
 			}
-	
+
 			// If there are functions bound, to execute
 			readyList.resolveWith( document, [ jQuery ] );
-	
+
 			// Trigger any bound ready events
 			if ( jQuery.fn.trigger ) {
 				jQuery( document ).trigger("ready").off("ready");
 			}
 		},
-	
+
 		// See test/unit/core.js for details concerning isFunction.
 		// Since version 1.3, DOM methods and functions like alert
 		// aren't supported. They return false on IE (#2968).
 		isFunction: function( obj ) {
 			return jQuery.type(obj) === "function";
 		},
-	
+
 		isArray: Array.isArray,
-	
+
 		isWindow: function( obj ) {
 			return obj != null && obj === obj.window;
 		},
-	
+
 		isNumeric: function( obj ) {
 			return !isNaN( parseFloat(obj) ) && isFinite( obj );
 		},
-	
+
 		type: function( obj ) {
 			if ( obj == null ) {
 				return String( obj );
@@ -1971,7 +1972,7 @@
 				class2type[ core_toString.call(obj) ] || "object" :
 				typeof obj;
 		},
-	
+
 		isPlainObject: function( obj ) {
 			// Not plain objects:
 			// - Any object or value whose internal [[Class]] property is not "[object Object]"
@@ -1980,7 +1981,7 @@
 			if ( jQuery.type( obj ) !== "object" || obj.nodeType || jQuery.isWindow( obj ) ) {
 				return false;
 			}
-	
+
 			// Support: Firefox <20
 			// The try/catch suppresses exceptions thrown when attempting to access
 			// the "constructor" property of certain host objects, ie. |window.location|
@@ -1993,12 +1994,12 @@
 			} catch ( e ) {
 				return false;
 			}
-	
+
 			// If the function hasn't returned already, we're confident that
 			// |obj| is a plain object, created by {} or constructed with new Object
 			return true;
 		},
-	
+
 		isEmptyObject: function( obj ) {
 			var name;
 			for ( name in obj ) {
@@ -2006,11 +2007,11 @@
 			}
 			return true;
 		},
-	
+
 		error: function( msg ) {
 			throw new Error( msg );
 		},
-	
+
 		// data: string of html
 		// context (optional): If specified, the fragment will be created in this context, defaults to document
 		// keepScripts (optional): If true, will include scripts passed in the html string
@@ -2023,33 +2024,33 @@
 				context = false;
 			}
 			context = context || document;
-	
+
 			var parsed = rsingleTag.exec( data ),
 				scripts = !keepScripts && [];
-	
+
 			// Single tag
 			if ( parsed ) {
 				return [ context.createElement( parsed[1] ) ];
 			}
-	
+
 			parsed = jQuery.buildFragment( [ data ], context, scripts );
-	
+
 			if ( scripts ) {
 				jQuery( scripts ).remove();
 			}
-	
+
 			return jQuery.merge( [], parsed.childNodes );
 		},
-	
+
 		parseJSON: JSON.parse,
-	
+
 		// Cross-browser xml parsing
 		parseXML: function( data ) {
 			var xml, tmp;
 			if ( !data || typeof data !== "string" ) {
 				return null;
 			}
-	
+
 			// Support: IE9
 			try {
 				tmp = new DOMParser();
@@ -2057,22 +2058,22 @@
 			} catch ( e ) {
 				xml = undefined;
 			}
-	
+
 			if ( !xml || xml.getElementsByTagName( "parsererror" ).length ) {
 				jQuery.error( "Invalid XML: " + data );
 			}
 			return xml;
 		},
-	
+
 		noop: function() {},
-	
+
 		// Evaluates a script in a global context
 		globalEval: function( code ) {
 			var script,
 					indirect = eval;
-	
+
 			code = jQuery.trim( code );
-	
+
 			if ( code ) {
 				// If the code includes a valid, prologue position
 				// strict mode pragma, execute code by injecting a
@@ -2088,29 +2089,29 @@
 				}
 			}
 		},
-	
+
 		// Convert dashed to camelCase; used by the css and data modules
 		// Microsoft forgot to hump their vendor prefix (#9572)
 		camelCase: function( string ) {
 			return string.replace( rmsPrefix, "ms-" ).replace( rdashAlpha, fcamelCase );
 		},
-	
+
 		nodeName: function( elem, name ) {
 			return elem.nodeName && elem.nodeName.toLowerCase() === name.toLowerCase();
 		},
-	
+
 		// args is for internal usage only
 		each: function( obj, callback, args ) {
 			var value,
 				i = 0,
 				length = obj.length,
 				isArray = isArraylike( obj );
-	
+
 			if ( args ) {
 				if ( isArray ) {
 					for ( ; i < length; i++ ) {
 						value = callback.apply( obj[ i ], args );
-	
+
 						if ( value === false ) {
 							break;
 						}
@@ -2118,19 +2119,19 @@
 				} else {
 					for ( i in obj ) {
 						value = callback.apply( obj[ i ], args );
-	
+
 						if ( value === false ) {
 							break;
 						}
 					}
 				}
-	
+
 			// A special, fast, case for the most common use of each
 			} else {
 				if ( isArray ) {
 					for ( ; i < length; i++ ) {
 						value = callback.call( obj[ i ], i, obj[ i ] );
-	
+
 						if ( value === false ) {
 							break;
 						}
@@ -2138,25 +2139,25 @@
 				} else {
 					for ( i in obj ) {
 						value = callback.call( obj[ i ], i, obj[ i ] );
-	
+
 						if ( value === false ) {
 							break;
 						}
 					}
 				}
 			}
-	
+
 			return obj;
 		},
-	
+
 		trim: function( text ) {
 			return text == null ? "" : core_trim.call( text );
 		},
-	
+
 		// results is for internal usage only
 		makeArray: function( arr, results ) {
 			var ret = results || [];
-	
+
 			if ( arr != null ) {
 				if ( isArraylike( Object(arr) ) ) {
 					jQuery.merge( ret,
@@ -2167,19 +2168,19 @@
 					core_push.call( ret, arr );
 				}
 			}
-	
+
 			return ret;
 		},
-	
+
 		inArray: function( elem, arr, i ) {
 			return arr == null ? -1 : core_indexOf.call( arr, elem, i );
 		},
-	
+
 		merge: function( first, second ) {
 			var l = second.length,
 				i = first.length,
 				j = 0;
-	
+
 			if ( typeof l === "number" ) {
 				for ( ; j < l; j++ ) {
 					first[ i++ ] = second[ j ];
@@ -2189,19 +2190,19 @@
 					first[ i++ ] = second[ j++ ];
 				}
 			}
-	
+
 			first.length = i;
-	
+
 			return first;
 		},
-	
+
 		grep: function( elems, callback, inv ) {
 			var retVal,
 				ret = [],
 				i = 0,
 				length = elems.length;
 			inv = !!inv;
-	
+
 			// Go through the array, only saving the items
 			// that pass the validator function
 			for ( ; i < length; i++ ) {
@@ -2210,10 +2211,10 @@
 					ret.push( elems[ i ] );
 				}
 			}
-	
+
 			return ret;
 		},
-	
+
 		// arg is for internal usage only
 		map: function( elems, callback, arg ) {
 			var value,
@@ -2221,92 +2222,92 @@
 				length = elems.length,
 				isArray = isArraylike( elems ),
 				ret = [];
-	
+
 			// Go through the array, translating each of the items to their
 			if ( isArray ) {
 				for ( ; i < length; i++ ) {
 					value = callback( elems[ i ], i, arg );
-	
+
 					if ( value != null ) {
 						ret[ ret.length ] = value;
 					}
 				}
-	
+
 			// Go through every key on the object,
 			} else {
 				for ( i in elems ) {
 					value = callback( elems[ i ], i, arg );
-	
+
 					if ( value != null ) {
 						ret[ ret.length ] = value;
 					}
 				}
 			}
-	
+
 			// Flatten any nested arrays
 			return core_concat.apply( [], ret );
 		},
-	
+
 		// A global GUID counter for objects
 		guid: 1,
-	
+
 		// Bind a function to a context, optionally partially applying any
 		// arguments.
 		proxy: function( fn, context ) {
 			var tmp, args, proxy;
-	
+
 			if ( typeof context === "string" ) {
 				tmp = fn[ context ];
 				context = fn;
 				fn = tmp;
 			}
-	
+
 			// Quick check to determine if target is callable, in the spec
 			// this throws a TypeError, but we will just return undefined.
 			if ( !jQuery.isFunction( fn ) ) {
 				return undefined;
 			}
-	
+
 			// Simulated bind
 			args = core_slice.call( arguments, 2 );
 			proxy = function() {
 				return fn.apply( context || this, args.concat( core_slice.call( arguments ) ) );
 			};
-	
+
 			// Set the guid of unique handler to the same of original handler, so it can be removed
 			proxy.guid = fn.guid = fn.guid || jQuery.guid++;
-	
+
 			return proxy;
 		},
-	
+
 		// Multifunctional method to get and set values of a collection
 		// The value/s can optionally be executed if it's a function
 		access: function( elems, fn, key, value, chainable, emptyGet, raw ) {
 			var i = 0,
 				length = elems.length,
 				bulk = key == null;
-	
+
 			// Sets many values
 			if ( jQuery.type( key ) === "object" ) {
 				chainable = true;
 				for ( i in key ) {
 					jQuery.access( elems, fn, i, key[i], true, emptyGet, raw );
 				}
-	
+
 			// Sets one value
 			} else if ( value !== undefined ) {
 				chainable = true;
-	
+
 				if ( !jQuery.isFunction( value ) ) {
 					raw = true;
 				}
-	
+
 				if ( bulk ) {
 					// Bulk operations run against the entire set
 					if ( raw ) {
 						fn.call( elems, value );
 						fn = null;
-	
+
 					// ...except when executing function values
 					} else {
 						bulk = fn;
@@ -2315,95 +2316,95 @@
 						};
 					}
 				}
-	
+
 				if ( fn ) {
 					for ( ; i < length; i++ ) {
 						fn( elems[i], key, raw ? value : value.call( elems[i], i, fn( elems[i], key ) ) );
 					}
 				}
 			}
-	
+
 			return chainable ?
 				elems :
-	
+
 				// Gets
 				bulk ?
 					fn.call( elems ) :
 					length ? fn( elems[0], key ) : emptyGet;
 		},
-	
+
 		now: Date.now,
-	
+
 		// A method for quickly swapping in/out CSS properties to get correct calculations.
 		// Note: this method belongs to the css module but it's needed here for the support module.
 		// If support gets modularized, this method should be moved back to the css module.
 		swap: function( elem, options, callback, args ) {
 			var ret, name,
 				old = {};
-	
+
 			// Remember the old values, and insert the new ones
 			for ( name in options ) {
 				old[ name ] = elem.style[ name ];
 				elem.style[ name ] = options[ name ];
 			}
-	
+
 			ret = callback.apply( elem, args || [] );
-	
+
 			// Revert the old values
 			for ( name in options ) {
 				elem.style[ name ] = old[ name ];
 			}
-	
+
 			return ret;
 		}
 	});
-	
+
 	jQuery.ready.promise = function( obj ) {
 		if ( !readyList ) {
-	
+
 			readyList = jQuery.Deferred();
-	
+
 			// Catch cases where $(document).ready() is called after the browser event has already occurred.
 			// we once tried to use readyState "interactive" here, but it caused issues like the one
 			// discovered by ChrisS here: http://bugs.jquery.com/ticket/12282#comment:15
 			if ( document.readyState === "complete" ) {
 				// Handle it asynchronously to allow scripts the opportunity to delay ready
 				setTimeout( jQuery.ready );
-	
+
 			} else {
-	
+
 				// Use the handy event callback
 				document.addEventListener( "DOMContentLoaded", completed, false );
-	
+
 				// A fallback to window.onload, that will always work
 				window.addEventListener( "load", completed, false );
 			}
 		}
 		return readyList.promise( obj );
 	};
-	
+
 	// Populate the class2type map
 	jQuery.each("Boolean Number String Function Array Date RegExp Object Error".split(" "), function(i, name) {
 		class2type[ "[object " + name + "]" ] = name.toLowerCase();
 	});
-	
+
 	function isArraylike( obj ) {
 		var length = obj.length,
 			type = jQuery.type( obj );
-	
+
 		if ( jQuery.isWindow( obj ) ) {
 			return false;
 		}
-	
+
 		if ( obj.nodeType === 1 && length ) {
 			return true;
 		}
-	
+
 		return type === "array" || type !== "function" &&
 			( length === 0 ||
 			typeof length === "number" && length > 0 && ( length - 1 ) in obj );
 	}
-	
+
 	// All jQuery objects should point back to these
 	rootjQuery = jQuery(document);
 	/*!
@@ -2417,7 +2418,7 @@
 	 * Date: 2013-06-03
 	 */
 	(function( window, undefined ) {
-	
+
 	var i,
 		support,
 		cachedruns,
@@ -2427,7 +2428,7 @@
 		compile,
 		outermostContext,
 		sortInput,
-	
+
 		// Local document vars
 		setDocument,
 		document,
@@ -2437,7 +2438,7 @@
 		rbuggyMatches,
 		matches,
 		contains,
-	
+
 		// Instance-specific data
 		expando = "sizzle" + -(new Date()),
 		preferredDoc = window.document,
@@ -2454,11 +2455,11 @@
 			}
 			return 0;
 		},
-	
+
 		// General-purpose constants
 		strundefined = typeof undefined,
 		MAX_NEGATIVE = 1 << 31,
-	
+
 		// Instance methods
 		hasOwn = ({}).hasOwnProperty,
 		arr = [],
@@ -2477,25 +2478,25 @@
 			}
 			return -1;
 		},
-	
+
 		booleans = "checked|selected|async|autofocus|autoplay|controls|defer|disabled|hidden|ismap|loop|multiple|open|readonly|required|scoped",
-	
+
 		// Regular expressions
-	
+
 		// Whitespace characters http://www.w3.org/TR/css3-selectors/#whitespace
 		whitespace = "[\\x20\\t\\r\\n\\f]",
 		// http://www.w3.org/TR/css3-syntax/#characters
 		characterEncoding = "(?:\\\\.|[\\w-]|[^\\x00-\\xa0])+",
-	
+
 		// Loosely modeled on CSS identifier characters
 		// An unquoted value should be a CSS identifier http://www.w3.org/TR/css3-selectors/#attribute-selectors
 		// Proper syntax: http://www.w3.org/TR/CSS21/syndata.html#value-def-identifier
 		identifier = characterEncoding.replace( "w", "w#" ),
-	
+
 		// Acceptable operators http://www.w3.org/TR/selectors/#attribute-selectors
 		attributes = "\\[" + whitespace + "*(" + characterEncoding + ")" + whitespace +
 			"*(?:([*^$|!~]?=)" + whitespace + "*(?:(['\"])((?:\\\\.|[^\\\\])*?)\\3|(" + identifier + ")|)|)" + whitespace + "*\\]",
-	
+
 		// Prefer arguments quoted,
 		//   then not containing pseudos/brackets,
 		//   then attribute selectors/non-parenthetical expressions,
@@ -2503,19 +2504,19 @@
 		// These preferences are here to reduce the number of selectors
 		//   needing tokenize in the PSEUDO preFilter
 		pseudos = ":(" + characterEncoding + ")(?:\\(((['\"])((?:\\\\.|[^\\\\])*?)\\3|((?:\\\\.|[^\\\\()[\\]]|" + attributes.replace( 3, 8 ) + ")*)|.*)\\)|)",
-	
+
 		// Leading and non-escaped trailing whitespace, capturing some non-whitespace characters preceding the latter
 		rtrim = new RegExp( "^" + whitespace + "+|((?:^|[^\\\\])(?:\\\\.)*)" + whitespace + "+$", "g" ),
-	
+
 		rcomma = new RegExp( "^" + whitespace + "*," + whitespace + "*" ),
 		rcombinators = new RegExp( "^" + whitespace + "*([>+~]|" + whitespace + ")" + whitespace + "*" ),
-	
+
 		rsibling = new RegExp( whitespace + "*[+~]" ),
 		rattributeQuotes = new RegExp( "=" + whitespace + "*([^\\]'\"]*)" + whitespace + "*\\]", "g" ),
-	
+
 		rpseudo = new RegExp( pseudos ),
 		ridentifier = new RegExp( "^" + identifier + "$" ),
-	
+
 		matchExpr = {
 			"ID": new RegExp( "^#(" + characterEncoding + ")" ),
 			"CLASS": new RegExp( "^\\.(" + characterEncoding + ")" ),
@@ -2531,17 +2532,17 @@
 			"needsContext": new RegExp( "^" + whitespace + "*[>+~]|:(even|odd|eq|gt|lt|nth|first|last)(?:\\(" +
 				whitespace + "*((?:-\\d)?\\d*)" + whitespace + "*\\)|)(?=[^-]|$)", "i" )
 		},
-	
+
 		rnative = /^[^{]+\{\s*\[native \w/,
-	
+
 		// Easily-parseable/retrievable ID or TAG or CLASS selectors
 		rquickExpr = /^(?:#([\w-]+)|(\w+)|\.([\w-]+))$/,
-	
+
 		rinputs = /^(?:input|select|textarea|button)$/i,
 		rheader = /^h\d$/i,
-	
+
 		rescape = /'|\\/g,
-	
+
 		// CSS escapes http://www.w3.org/TR/CSS21/syndata.html#escaped-characters
 		runescape = new RegExp( "\\\\([\\da-f]{1,6}" + whitespace + "?|(" + whitespace + ")|.)", "ig" ),
 		funescape = function( _, escaped, escapedWhitespace ) {
@@ -2557,7 +2558,7 @@
 					// Supplemental Plane codepoint (surrogate pair)
 					String.fromCharCode( high >> 10 | 0xD800, high & 0x3FF | 0xDC00 );
 		};
-	
+
 	// Optimize for push.apply( _, NodeList )
 	try {
 		push.apply(
@@ -2569,12 +2570,12 @@
 		arr[ preferredDoc.childNodes.length ].nodeType;
 	} catch ( e ) {
 		push = { apply: arr.length ?
-	
+
 			// Leverage slice if possible
 			function( target, els ) {
 				push_native.apply( target, slice.call(els) );
 			} :
-	
+
 			// Support: IE<9
 			// Otherwise append directly
 			function( target, els ) {
@@ -2586,29 +2587,29 @@
 			}
 		};
 	}
-	
+
 	function Sizzle( selector, context, results, seed ) {
 		var match, elem, m, nodeType,
 			// QSA vars
 			i, groups, old, nid, newContext, newSelector;
-	
+
 		if ( ( context ? context.ownerDocument || context : preferredDoc ) !== document ) {
 			setDocument( context );
 		}
-	
+
 		context = context || document;
 		results = results || [];
-	
+
 		if ( !selector || typeof selector !== "string" ) {
 			return results;
 		}
-	
+
 		if ( (nodeType = context.nodeType) !== 1 && nodeType !== 9 ) {
 			return [];
 		}
-	
+
 		if ( documentIsHTML && !seed ) {
-	
+
 			// Shortcuts
 			if ( (match = rquickExpr.exec( selector )) ) {
 				// Speed-up: Sizzle("#ID")
@@ -2635,39 +2636,39 @@
 							return results;
 						}
 					}
-	
+
 				// Speed-up: Sizzle("TAG")
 				} else if ( match[2] ) {
 					push.apply( results, context.getElementsByTagName( selector ) );
 					return results;
-	
+
 				// Speed-up: Sizzle(".CLASS")
 				} else if ( (m = match[3]) && support.getElementsByClassName && context.getElementsByClassName ) {
 					push.apply( results, context.getElementsByClassName( m ) );
 					return results;
 				}
 			}
-	
+
 			// QSA path
 			if ( support.qsa && (!rbuggyQSA || !rbuggyQSA.test( selector )) ) {
 				nid = old = expando;
 				newContext = context;
 				newSelector = nodeType === 9 && selector;
-	
+
 				// qSA works strangely on Element-rooted queries
 				// We can work around this by specifying an extra ID on the root
 				// and working up from there (Thanks to Andrew Dupont for the technique)
 				// IE 8 doesn't work on object elements
 				if ( nodeType === 1 && context.nodeName.toLowerCase() !== "object" ) {
 					groups = tokenize( selector );
-	
+
 					if ( (old = context.getAttribute("id")) ) {
 						nid = old.replace( rescape, "\\$&" );
 					} else {
 						context.setAttribute( "id", nid );
 					}
 					nid = "[id='" + nid + "'] ";
-	
+
 					i = groups.length;
 					while ( i-- ) {
 						groups[i] = nid + toSelector( groups[i] );
@@ -2675,7 +2676,7 @@
 					newContext = rsibling.test( selector ) && context.parentNode || context;
 					newSelector = groups.join(",");
 				}
-	
+
 				if ( newSelector ) {
 					try {
 						push.apply( results,
@@ -2691,11 +2692,11 @@
 				}
 			}
 		}
-	
+
 		// All others
 		return select( selector.replace( rtrim, "$1" ), context, results, seed );
 	}
-	
+
 	/**
 	 * Create key-value caches of limited size
 	 * @returns {Function(string, Object)} Returns the Object data after storing it on itself with
@@ -2704,7 +2705,7 @@
 	 */
 	function createCache() {
 		var keys = [];
-	
+
 		function cache( key, value ) {
 			// Use (key + " ") to avoid collision with native prototype properties (see Issue #157)
 			if ( keys.push( key += " " ) > Expr.cacheLength ) {
@@ -2715,7 +2716,7 @@
 		}
 		return cache;
 	}
-	
+
 	/**
 	 * Mark a function for special use by Sizzle
 	 * @param {Function} fn The function to mark
@@ -2724,14 +2725,14 @@
 		fn[ expando ] = true;
 		return fn;
 	}
-	
+
 	/**
 	 * Support testing using an element
 	 * @param {Function} fn Passed the created div and expects a boolean result
 	 */
 	function assert( fn ) {
 		var div = document.createElement("div");
-	
+
 		try {
 			return !!fn( div );
 		} catch (e) {
@@ -2745,7 +2746,7 @@
 			div = null;
 		}
 	}
-	
+
 	/**
 	 * Adds the same handler for all of the specified attrs
 	 * @param {String} attrs Pipe-separated list of attributes
@@ -2754,12 +2755,12 @@
 	function addHandle( attrs, handler ) {
 		var arr = attrs.split("|"),
 			i = attrs.length;
-	
+
 		while ( i-- ) {
 			Expr.attrHandle[ arr[i] ] = handler;
 		}
 	}
-	
+
 	/**
 	 * Checks document order of two siblings
 	 * @param {Element} a
@@ -2771,12 +2772,12 @@
 			diff = cur && a.nodeType === 1 && b.nodeType === 1 &&
 				( ~b.sourceIndex || MAX_NEGATIVE ) -
 				( ~a.sourceIndex || MAX_NEGATIVE );
-	
+
 		// Use IE sourceIndex if available on both nodes
 		if ( diff ) {
 			return diff;
 		}
-	
+
 		// Check if b follows a
 		if ( cur ) {
 			while ( (cur = cur.nextSibling) ) {
@@ -2785,10 +2786,10 @@
 				}
 			}
 		}
-	
+
 		return a ? 1 : -1;
 	}
-	
+
 	/**
 	 * Returns a function to use in pseudos for input types
 	 * @param {String} type
@@ -2799,7 +2800,7 @@
 			return name === "input" && elem.type === type;
 		};
 	}
-	
+
 	/**
 	 * Returns a function to use in pseudos for buttons
 	 * @param {String} type
@@ -2810,7 +2811,7 @@
 			return (name === "input" || name === "button") && elem.type === type;
 		};
 	}
-	
+
 	/**
 	 * Returns a function to use in pseudos for positionals
 	 * @param {Function} fn
@@ -2822,7 +2823,7 @@
 				var j,
 					matchIndexes = fn( [], seed.length, argument ),
 					i = matchIndexes.length;
-	
+
 				// Match elements found at the specified indexes
 				while ( i-- ) {
 					if ( seed[ (j = matchIndexes[i]) ] ) {
@@ -2832,7 +2833,7 @@
 			});
 		});
 	}
-	
+
 	/**
 	 * Detect xml
 	 * @param {Element|Object} elem An element or a document
@@ -2843,10 +2844,10 @@
 		var documentElement = elem && (elem.ownerDocument || elem).documentElement;
 		return documentElement ? documentElement.nodeName !== "HTML" : false;
 	};
-	
+
 	// Expose support vars for convenience
 	support = Sizzle.support = {};
-	
+
 	/**
 	 * Sets document-related variables once based on the current document
 	 * @param {Element|Object} [doc] An element or document object to use to set the document
@@ -2855,19 +2856,19 @@
 	setDocument = Sizzle.setDocument = function( node ) {
 		var doc = node ? node.ownerDocument || node : preferredDoc,
 			parent = doc.defaultView;
-	
+
 		// If no document and documentElement is available, return
 		if ( doc === document || doc.nodeType !== 9 || !doc.documentElement ) {
 			return document;
 		}
-	
+
 		// Set our document
 		document = doc;
 		docElem = doc.documentElement;
-	
+
 		// Support tests
 		documentIsHTML = !isXML( doc );
-	
+
 		// Support: IE>8
 		// If iframe document is assigned to "document" variable and if iframe has been reloaded,
 		// IE will throw "permission denied" error when accessing "document" variable, see jQuery #13936
@@ -2877,30 +2878,30 @@
 				setDocument();
 			});
 		}
-	
+
 		/* Attributes
 		---------------------------------------------------------------------- */
-	
+
 		// Support: IE<8
 		// Verify that getAttribute really returns attributes and not properties (excepting IE8 booleans)
 		support.attributes = assert(function( div ) {
 			div.className = "i";
 			return !div.getAttribute("className");
 		});
-	
+
 		/* getElement(s)By*
 		---------------------------------------------------------------------- */
-	
+
 		// Check if getElementsByTagName("*") returns only elements
 		support.getElementsByTagName = assert(function( div ) {
 			div.appendChild( doc.createComment("") );
 			return !div.getElementsByTagName("*").length;
 		});
-	
+
 		// Check if getElementsByClassName can be trusted
 		support.getElementsByClassName = assert(function( div ) {
 			div.innerHTML = "<div class='a'></div><div class='a i'></div>";
-	
+
 			// Support: Safari<4
 			// Catch class over-caching
 			div.firstChild.className = "i";
@@ -2908,7 +2909,7 @@
 			// Catch gEBCN failure to find non-leading classes
 			return div.getElementsByClassName("i").length === 2;
 		});
-	
+
 		// Support: IE<10
 		// Check if getElementById returns elements by name
 		// The broken getElementById methods don't pick up programatically-set names,
@@ -2917,7 +2918,7 @@
 			docElem.appendChild( div ).id = expando;
 			return !doc.getElementsByName || !doc.getElementsByName( expando ).length;
 		});
-	
+
 		// ID find and filter
 		if ( support.getById ) {
 			Expr.find["ID"] = function( id, context ) {
@@ -2938,7 +2939,7 @@
 			// Support: IE6/7
 			// getElementById is not reliable as a find shortcut
 			delete Expr.find["ID"];
-	
+
 			Expr.filter["ID"] =  function( id ) {
 				var attrId = id.replace( runescape, funescape );
 				return function( elem ) {
@@ -2947,7 +2948,7 @@
 				};
 			};
 		}
-	
+
 		// Tag
 		Expr.find["TAG"] = support.getElementsByTagName ?
 			function( tag, context ) {
@@ -2960,7 +2961,7 @@
 					tmp = [],
 					i = 0,
 					results = context.getElementsByTagName( tag );
-	
+
 				// Filter out possible comments
 				if ( tag === "*" ) {
 					while ( (elem = results[i++]) ) {
@@ -2968,34 +2969,34 @@
 							tmp.push( elem );
 						}
 					}
-	
+
 					return tmp;
 				}
 				return results;
 			};
-	
+
 		// Class
 		Expr.find["CLASS"] = support.getElementsByClassName && function( className, context ) {
 			if ( typeof context.getElementsByClassName !== strundefined && documentIsHTML ) {
 				return context.getElementsByClassName( className );
 			}
 		};
-	
+
 		/* QSA/matchesSelector
 		---------------------------------------------------------------------- */
-	
+
 		// QSA and matchesSelector support
-	
+
 		// matchesSelector(:active) reports false when true (IE9/Opera 11.5)
 		rbuggyMatches = [];
-	
+
 		// qSa(:focus) reports false when true (Chrome 21)
 		// We allow this because of a bug in IE8/9 that throws an error
 		// whenever `document.activeElement` is accessed on an iframe
 		// So, we allow :focus to pass through QSA all the time to avoid the IE error
 		// See http://bugs.jquery.com/ticket/13378
 		rbuggyQSA = [];
-	
+
 		if ( (support.qsa = rnative.test( doc.querySelectorAll )) ) {
 			// Build QSA regex
 			// Regex strategy adopted from Diego Perini
@@ -3006,13 +3007,13 @@
 				// since its presence should be enough
 				// http://bugs.jquery.com/ticket/12359
 				div.innerHTML = "<select><option selected=''></option></select>";
-	
+
 				// Support: IE8
 				// Boolean attributes and "value" are not treated correctly
 				if ( !div.querySelectorAll("[selected]").length ) {
 					rbuggyQSA.push( "\\[" + whitespace + "*(?:value|" + booleans + ")" );
 				}
-	
+
 				// Webkit/Opera - :checked should return selected option elements
 				// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
 				// IE8 throws error here and will not see later tests
@@ -3020,9 +3021,9 @@
 					rbuggyQSA.push(":checked");
 				}
 			});
-	
+
 			assert(function( div ) {
-	
+
 				// Support: Opera 10-12/IE8
 				// ^= $= *= and empty values
 				// Should not select anything
@@ -3031,46 +3032,46 @@
 				var input = doc.createElement("input");
 				input.setAttribute( "type", "hidden" );
 				div.appendChild( input ).setAttribute( "t", "" );
-	
+
 				if ( div.querySelectorAll("[t^='']").length ) {
 					rbuggyQSA.push( "[*^$]=" + whitespace + "*(?:''|\"\")" );
 				}
-	
+
 				// FF 3.5 - :enabled/:disabled and hidden elements (hidden elements are still enabled)
 				// IE8 throws error here and will not see later tests
 				if ( !div.querySelectorAll(":enabled").length ) {
 					rbuggyQSA.push( ":enabled", ":disabled" );
 				}
-	
+
 				// Opera 10-11 does not throw on post-comma invalid pseudos
 				div.querySelectorAll("*,:x");
 				rbuggyQSA.push(",.*:");
 			});
 		}
-	
+
 		if ( (support.matchesSelector = rnative.test( (matches = docElem.webkitMatchesSelector ||
 			docElem.mozMatchesSelector ||
 			docElem.oMatchesSelector ||
 			docElem.msMatchesSelector) )) ) {
-	
+
 			assert(function( div ) {
 				// Check to see if it's possible to do matchesSelector
 				// on a disconnected node (IE 9)
 				support.disconnectedMatch = matches.call( div, "div" );
-	
+
 				// This should fail with an exception
 				// Gecko does not error, returns false instead
 				matches.call( div, "[s!='']:x" );
 				rbuggyMatches.push( "!=", pseudos );
 			});
 		}
-	
+
 		rbuggyQSA = rbuggyQSA.length && new RegExp( rbuggyQSA.join("|") );
 		rbuggyMatches = rbuggyMatches.length && new RegExp( rbuggyMatches.join("|") );
-	
+
 		/* Contains
 		---------------------------------------------------------------------- */
-	
+
 		// Element contains another
 		// Purposefully does not implement inclusive descendent
 		// As in, an element does not contain itself
@@ -3094,27 +3095,27 @@
 				}
 				return false;
 			};
-	
+
 		/* Sorting
 		---------------------------------------------------------------------- */
-	
+
 		// Document order sorting
 		sortOrder = docElem.compareDocumentPosition ?
 		function( a, b ) {
-	
+
 			// Flag for duplicate removal
 			if ( a === b ) {
 				hasDuplicate = true;
 				return 0;
 			}
-	
+
 			var compare = b.compareDocumentPosition && a.compareDocumentPosition && a.compareDocumentPosition( b );
-	
+
 			if ( compare ) {
 				// Disconnected nodes
 				if ( compare & 1 ||
 					(!support.sortDetached && b.compareDocumentPosition( a ) === compare) ) {
-	
+
 					// Choose the first element that is related to our preferred document
 					if ( a === doc || contains(preferredDoc, a) ) {
 						return -1;
@@ -3122,16 +3123,16 @@
 					if ( b === doc || contains(preferredDoc, b) ) {
 						return 1;
 					}
-	
+
 					// Maintain original order
 					return sortInput ?
 						( indexOf.call( sortInput, a ) - indexOf.call( sortInput, b ) ) :
 						0;
 				}
-	
+
 				return compare & 4 ? -1 : 1;
 			}
-	
+
 			// Not directly comparable, sort on existence of method
 			return a.compareDocumentPosition ? -1 : 1;
 		} :
@@ -3142,12 +3143,12 @@
 				bup = b.parentNode,
 				ap = [ a ],
 				bp = [ b ];
-	
+
 			// Exit early if the nodes are identical
 			if ( a === b ) {
 				hasDuplicate = true;
 				return 0;
-	
+
 			// Parentless nodes are either documents or disconnected
 			} else if ( !aup || !bup ) {
 				return a === doc ? -1 :
@@ -3157,12 +3158,12 @@
 					sortInput ?
 					( indexOf.call( sortInput, a ) - indexOf.call( sortInput, b ) ) :
 					0;
-	
+
 			// If the nodes are siblings, we can do a quick check
 			} else if ( aup === bup ) {
 				return siblingCheck( a, b );
 			}
-	
+
 			// Otherwise we need full lists of their ancestors for comparison
 			cur = a;
 			while ( (cur = cur.parentNode) ) {
@@ -3172,45 +3173,45 @@
 			while ( (cur = cur.parentNode) ) {
 				bp.unshift( cur );
 			}
-	
+
 			// Walk down the tree looking for a discrepancy
 			while ( ap[i] === bp[i] ) {
 				i++;
 			}
-	
+
 			return i ?
 				// Do a sibling check if the nodes have a common ancestor
 				siblingCheck( ap[i], bp[i] ) :
-	
+
 				// Otherwise nodes in our document sort first
 				ap[i] === preferredDoc ? -1 :
 				bp[i] === preferredDoc ? 1 :
 				0;
 		};
-	
+
 		return doc;
 	};
-	
+
 	Sizzle.matches = function( expr, elements ) {
 		return Sizzle( expr, null, null, elements );
 	};
-	
+
 	Sizzle.matchesSelector = function( elem, expr ) {
 		// Set document vars if needed
 		if ( ( elem.ownerDocument || elem ) !== document ) {
 			setDocument( elem );
 		}
-	
+
 		// Make sure that attribute selectors are quoted
 		expr = expr.replace( rattributeQuotes, "='$1']" );
-	
+
 		if ( support.matchesSelector && documentIsHTML &&
 			( !rbuggyMatches || !rbuggyMatches.test( expr ) ) &&
 			( !rbuggyQSA     || !rbuggyQSA.test( expr ) ) ) {
-	
+
 			try {
 				var ret = matches.call( elem, expr );
-	
+
 				// IE 9's matchesSelector returns false on disconnected nodes
 				if ( ret || support.disconnectedMatch ||
 						// As well, disconnected nodes are said to be in a document
@@ -3220,10 +3221,10 @@
 				}
 			} catch(e) {}
 		}
-	
+
 		return Sizzle( expr, document, null, [elem] ).length > 0;
 	};
-	
+
 	Sizzle.contains = function( context, elem ) {
 		// Set document vars if needed
 		if ( ( context.ownerDocument || context ) !== document ) {
@@ -3231,19 +3232,19 @@
 		}
 		return contains( context, elem );
 	};
-	
+
 	Sizzle.attr = function( elem, name ) {
 		// Set document vars if needed
 		if ( ( elem.ownerDocument || elem ) !== document ) {
 			setDocument( elem );
 		}
-	
+
 		var fn = Expr.attrHandle[ name.toLowerCase() ],
 			// Don't get fooled by Object.prototype properties (jQuery #13807)
 			val = fn && hasOwn.call( Expr.attrHandle, name.toLowerCase() ) ?
 				fn( elem, name, !documentIsHTML ) :
 				undefined;
-	
+
 		return val === undefined ?
 			support.attributes || !documentIsHTML ?
 				elem.getAttribute( name ) :
@@ -3252,11 +3253,11 @@
 					null :
 			val;
 	};
-	
+
 	Sizzle.error = function( msg ) {
 		throw new Error( "Syntax error, unrecognized expression: " + msg );
 	};
-	
+
 	/**
 	 * Document sorting and removing duplicates
 	 * @param {ArrayLike} results
@@ -3266,12 +3267,12 @@
 			duplicates = [],
 			j = 0,
 			i = 0;
-	
+
 		// Unless we *know* we can detect duplicates, assume their presence
 		hasDuplicate = !support.detectDuplicates;
 		sortInput = !support.sortStable && results.slice( 0 );
 		results.sort( sortOrder );
-	
+
 		if ( hasDuplicate ) {
 			while ( (elem = results[i++]) ) {
 				if ( elem === results[ i ] ) {
@@ -3282,10 +3283,10 @@
 				results.splice( duplicates[ j ], 1 );
 			}
 		}
-	
+
 		return results;
 	};
-	
+
 	/**
 	 * Utility function for retrieving the text value of an array of DOM nodes
 	 * @param {Array|Element} elem
@@ -3295,7 +3296,7 @@
 			ret = "",
 			i = 0,
 			nodeType = elem.nodeType;
-	
+
 		if ( !nodeType ) {
 			// If no nodeType, this is expected to be an array
 			for ( ; (node = elem[i]); i++ ) {
@@ -3317,44 +3318,44 @@
 			return elem.nodeValue;
 		}
 		// Do not include comment or processing instruction nodes
-	
+
 		return ret;
 	};
-	
+
 	Expr = Sizzle.selectors = {
-	
+
 		// Can be adjusted by the user
 		cacheLength: 50,
-	
+
 		createPseudo: markFunction,
-	
+
 		match: matchExpr,
-	
+
 		attrHandle: {},
-	
+
 		find: {},
-	
+
 		relative: {
 			">": { dir: "parentNode", first: true },
 			" ": { dir: "parentNode" },
 			"+": { dir: "previousSibling", first: true },
 			"~": { dir: "previousSibling" }
 		},
-	
+
 		preFilter: {
 			"ATTR": function( match ) {
 				match[1] = match[1].replace( runescape, funescape );
-	
+
 				// Move the given value to match[3] whether quoted or unquoted
 				match[3] = ( match[4] || match[5] || "" ).replace( runescape, funescape );
-	
+
 				if ( match[2] === "~=" ) {
 					match[3] = " " + match[3] + " ";
 				}
-	
+
 				return match.slice( 0, 4 );
 			},
-	
+
 			"CHILD": function( match ) {
 				/* matches from matchExpr["CHILD"]
 					1 type (only|nth|...)
@@ -3367,57 +3368,57 @@
 					8 y of y-component
 				*/
 				match[1] = match[1].toLowerCase();
-	
+
 				if ( match[1].slice( 0, 3 ) === "nth" ) {
 					// nth-* requires argument
 					if ( !match[3] ) {
 						Sizzle.error( match[0] );
 					}
-	
+
 					// numeric x and y parameters for Expr.filter.CHILD
 					// remember that false/true cast respectively to 0/1
 					match[4] = +( match[4] ? match[5] + (match[6] || 1) : 2 * ( match[3] === "even" || match[3] === "odd" ) );
 					match[5] = +( ( match[7] + match[8] ) || match[3] === "odd" );
-	
+
 				// other types prohibit arguments
 				} else if ( match[3] ) {
 					Sizzle.error( match[0] );
 				}
-	
+
 				return match;
 			},
-	
+
 			"PSEUDO": function( match ) {
 				var excess,
 					unquoted = !match[5] && match[2];
-	
+
 				if ( matchExpr["CHILD"].test( match[0] ) ) {
 					return null;
 				}
-	
+
 				// Accept quoted arguments as-is
 				if ( match[3] && match[4] !== undefined ) {
 					match[2] = match[4];
-	
+
 				// Strip excess characters from unquoted arguments
 				} else if ( unquoted && rpseudo.test( unquoted ) &&
 					// Get excess from tokenize (recursively)
 					(excess = tokenize( unquoted, true )) &&
 					// advance to the next closing parenthesis
 					(excess = unquoted.indexOf( ")", unquoted.length - excess ) - unquoted.length) ) {
-	
+
 					// excess is a negative index
 					match[0] = match[0].slice( 0, excess );
 					match[2] = unquoted.slice( 0, excess );
 				}
-	
+
 				// Return only captures needed by the pseudo filter method (type and argument)
 				return match.slice( 0, 3 );
 			}
 		},
-	
+
 		filter: {
-	
+
 			"TAG": function( nodeNameSelector ) {
 				var nodeName = nodeNameSelector.replace( runescape, funescape ).toLowerCase();
 				return nodeNameSelector === "*" ?
@@ -3426,30 +3427,30 @@
 						return elem.nodeName && elem.nodeName.toLowerCase() === nodeName;
 					};
 			},
-	
+
 			"CLASS": function( className ) {
 				var pattern = classCache[ className + " " ];
-	
+
 				return pattern ||
 					(pattern = new RegExp( "(^|" + whitespace + ")" + className + "(" + whitespace + "|$)" )) &&
 					classCache( className, function( elem ) {
 						return pattern.test( typeof elem.className === "string" && elem.className || typeof elem.getAttribute !== strundefined && elem.getAttribute("class") || "" );
 					});
 			},
-	
+
 			"ATTR": function( name, operator, check ) {
 				return function( elem ) {
 					var result = Sizzle.attr( elem, name );
-	
+
 					if ( result == null ) {
 						return operator === "!=";
 					}
 					if ( !operator ) {
 						return true;
 					}
-	
+
 					result += "";
-	
+
 					return operator === "=" ? result === check :
 						operator === "!=" ? result !== check :
 						operator === "^=" ? check && result.indexOf( check ) === 0 :
@@ -3460,28 +3461,28 @@
 						false;
 				};
 			},
-	
+
 			"CHILD": function( type, what, argument, first, last ) {
 				var simple = type.slice( 0, 3 ) !== "nth",
 					forward = type.slice( -4 ) !== "last",
 					ofType = what === "of-type";
-	
+
 				return first === 1 && last === 0 ?
-	
+
 					// Shortcut for :nth-*(n)
 					function( elem ) {
 						return !!elem.parentNode;
 					} :
-	
+
 					function( elem, context, xml ) {
 						var cache, outerCache, node, diff, nodeIndex, start,
 							dir = simple !== forward ? "nextSibling" : "previousSibling",
 							parent = elem.parentNode,
 							name = ofType && elem.nodeName.toLowerCase(),
 							useCache = !xml && !ofType;
-	
+
 						if ( parent ) {
-	
+
 							// :(first|last|only)-(child|of-type)
 							if ( simple ) {
 								while ( dir ) {
@@ -3496,9 +3497,9 @@
 								}
 								return true;
 							}
-	
+
 							start = [ forward ? parent.firstChild : parent.lastChild ];
-	
+
 							// non-xml :nth-child(...) stores cache data on `parent`
 							if ( forward && useCache ) {
 								// Seek `elem` from a previously-cached index
@@ -3507,49 +3508,49 @@
 								nodeIndex = cache[0] === dirruns && cache[1];
 								diff = cache[0] === dirruns && cache[2];
 								node = nodeIndex && parent.childNodes[ nodeIndex ];
-	
+
 								while ( (node = ++nodeIndex && node && node[ dir ] ||
-	
+
 									// Fallback to seeking `elem` from the start
 									(diff = nodeIndex = 0) || start.pop()) ) {
-	
+
 									// When found, cache indexes on `parent` and break
 									if ( node.nodeType === 1 && ++diff && node === elem ) {
 										outerCache[ type ] = [ dirruns, nodeIndex, diff ];
 										break;
 									}
 								}
-	
+
 							// Use previously-cached element index if available
 							} else if ( useCache && (cache = (elem[ expando ] || (elem[ expando ] = {}))[ type ]) && cache[0] === dirruns ) {
 								diff = cache[1];
-	
+
 							// xml :nth-child(...) or :nth-last-child(...) or :nth(-last)?-of-type(...)
 							} else {
 								// Use the same loop as above to seek `elem` from the start
 								while ( (node = ++nodeIndex && node && node[ dir ] ||
 									(diff = nodeIndex = 0) || start.pop()) ) {
-	
+
 									if ( ( ofType ? node.nodeName.toLowerCase() === name : node.nodeType === 1 ) && ++diff ) {
 										// Cache the index of each encountered element
 										if ( useCache ) {
 											(node[ expando ] || (node[ expando ] = {}))[ type ] = [ dirruns, diff ];
 										}
-	
+
 										if ( node === elem ) {
 											break;
 										}
 									}
 								}
 							}
-	
+
 							// Incorporate the offset, then check against cycle size
 							diff -= last;
 							return diff === first || ( diff % first === 0 && diff / first >= 0 );
 						}
 					};
 			},
-	
+
 			"PSEUDO": function( pseudo, argument ) {
 				// pseudo-class names are case-insensitive
 				// http://www.w3.org/TR/selectors/#pseudo-classes
@@ -3558,14 +3559,14 @@
 				var args,
 					fn = Expr.pseudos[ pseudo ] || Expr.setFilters[ pseudo.toLowerCase() ] ||
 						Sizzle.error( "unsupported pseudo: " + pseudo );
-	
+
 				// The user may use createPseudo to indicate that
 				// arguments are needed to create the filter function
 				// just as Sizzle does
 				if ( fn[ expando ] ) {
 					return fn( argument );
 				}
-	
+
 				// But maintain support for old signatures
 				if ( fn.length > 1 ) {
 					args = [ pseudo, pseudo, "", argument ];
@@ -3583,11 +3584,11 @@
 							return fn( elem, 0, args );
 						};
 				}
-	
+
 				return fn;
 			}
 		},
-	
+
 		pseudos: {
 			// Potentially complex pseudos
 			"not": markFunction(function( selector ) {
@@ -3597,13 +3598,13 @@
 				var input = [],
 					results = [],
 					matcher = compile( selector.replace( rtrim, "$1" ) );
-	
+
 				return matcher[ expando ] ?
 					markFunction(function( seed, matches, context, xml ) {
 						var elem,
 							unmatched = matcher( seed, null, xml, [] ),
 							i = seed.length;
-	
+
 						// Match elements unmatched by `matcher`
 						while ( i-- ) {
 							if ( (elem = unmatched[i]) ) {
@@ -3617,19 +3618,19 @@
 						return !results.pop();
 					};
 			}),
-	
+
 			"has": markFunction(function( selector ) {
 				return function( elem ) {
 					return Sizzle( selector, elem ).length > 0;
 				};
 			}),
-	
+
 			"contains": markFunction(function( text ) {
 				return function( elem ) {
 					return ( elem.textContent || elem.innerText || getText( elem ) ).indexOf( text ) > -1;
 				};
 			}),
-	
+
 			// "Whether an element is represented by a :lang() selector
 			// is based solely on the element's language value
 			// being equal to the identifier C,
@@ -3649,7 +3650,7 @@
 						if ( (elemLang = documentIsHTML ?
 							elem.lang :
 							elem.getAttribute("xml:lang") || elem.getAttribute("lang")) ) {
-	
+
 							elemLang = elemLang.toLowerCase();
 							return elemLang === lang || elemLang.indexOf( lang + "-" ) === 0;
 						}
@@ -3657,47 +3658,47 @@
 					return false;
 				};
 			}),
-	
+
 			// Miscellaneous
 			"target": function( elem ) {
 				var hash = window.location && window.location.hash;
 				return hash && hash.slice( 1 ) === elem.id;
 			},
-	
+
 			"root": function( elem ) {
 				return elem === docElem;
 			},
-	
+
 			"focus": function( elem ) {
 				return elem === document.activeElement && (!document.hasFocus || document.hasFocus()) && !!(elem.type || elem.href || ~elem.tabIndex);
 			},
-	
+
 			// Boolean properties
 			"enabled": function( elem ) {
 				return elem.disabled === false;
 			},
-	
+
 			"disabled": function( elem ) {
 				return elem.disabled === true;
 			},
-	
+
 			"checked": function( elem ) {
 				// In CSS3, :checked should return both checked and selected elements
 				// http://www.w3.org/TR/2011/REC-css3-selectors-20110929/#checked
 				var nodeName = elem.nodeName.toLowerCase();
 				return (nodeName === "input" && !!elem.checked) || (nodeName === "option" && !!elem.selected);
 			},
-	
+
 			"selected": function( elem ) {
 				// Accessing this property makes selected-by-default
 				// options in Safari work properly
 				if ( elem.parentNode ) {
 					elem.parentNode.selectedIndex;
 				}
-	
+
 				return elem.selected === true;
 			},
-	
+
 			// Contents
 			"empty": function( elem ) {
 				// http://www.w3.org/TR/selectors/#empty-pseudo
@@ -3712,25 +3713,25 @@
 				}
 				return true;
 			},
-	
+
 			"parent": function( elem ) {
 				return !Expr.pseudos["empty"]( elem );
 			},
-	
+
 			// Element/input types
 			"header": function( elem ) {
 				return rheader.test( elem.nodeName );
 			},
-	
+
 			"input": function( elem ) {
 				return rinputs.test( elem.nodeName );
 			},
-	
+
 			"button": function( elem ) {
 				var name = elem.nodeName.toLowerCase();
 				return name === "input" && elem.type === "button" || name === "button";
 			},
-	
+
 			"text": function( elem ) {
 				var attr;
 				// IE6 and 7 will map elem.type to 'text' for new HTML5 types (search, etc)
@@ -3739,20 +3740,20 @@
 					elem.type === "text" &&
 					( (attr = elem.getAttribute("type")) == null || attr.toLowerCase() === elem.type );
 			},
-	
+
 			// Position-in-collection
 			"first": createPositionalPseudo(function() {
 				return [ 0 ];
 			}),
-	
+
 			"last": createPositionalPseudo(function( matchIndexes, length ) {
 				return [ length - 1 ];
 			}),
-	
+
 			"eq": createPositionalPseudo(function( matchIndexes, length, argument ) {
 				return [ argument < 0 ? argument + length : argument ];
 			}),
-	
+
 			"even": createPositionalPseudo(function( matchIndexes, length ) {
 				var i = 0;
 				for ( ; i < length; i += 2 ) {
@@ -3760,7 +3761,7 @@
 				}
 				return matchIndexes;
 			}),
-	
+
 			"odd": createPositionalPseudo(function( matchIndexes, length ) {
 				var i = 1;
 				for ( ; i < length; i += 2 ) {
@@ -3768,7 +3769,7 @@
 				}
 				return matchIndexes;
 			}),
-	
+
 			"lt": createPositionalPseudo(function( matchIndexes, length, argument ) {
 				var i = argument < 0 ? argument + length : argument;
 				for ( ; --i >= 0; ) {
@@ -3776,7 +3777,7 @@
 				}
 				return matchIndexes;
 			}),
-	
+
 			"gt": createPositionalPseudo(function( matchIndexes, length, argument ) {
 				var i = argument < 0 ? argument + length : argument;
 				for ( ; ++i < length; ) {
@@ -3786,9 +3787,9 @@
 			})
 		}
 	};
-	
+
 	Expr.pseudos["nth"] = Expr.pseudos["eq"];
-	
+
 	// Add button/input type pseudos
 	for ( i in { radio: true, checkbox: true, file: true, password: true, image: true } ) {
 		Expr.pseudos[ i ] = createInputPseudo( i );
@@ -3796,27 +3797,27 @@
 	for ( i in { submit: true, reset: true } ) {
 		Expr.pseudos[ i ] = createButtonPseudo( i );
 	}
-	
+
 	// Easy API for creating new setFilters
 	function setFilters() {}
 	setFilters.prototype = Expr.filters = Expr.pseudos;
 	Expr.setFilters = new setFilters();
-	
+
 	function tokenize( selector, parseOnly ) {
 		var matched, match, tokens, type,
 			soFar, groups, preFilters,
 			cached = tokenCache[ selector + " " ];
-	
+
 		if ( cached ) {
 			return parseOnly ? 0 : cached.slice( 0 );
 		}
-	
+
 		soFar = selector;
 		groups = [];
 		preFilters = Expr.preFilter;
-	
+
 		while ( soFar ) {
-	
+
 			// Comma and first run
 			if ( !matched || (match = rcomma.exec( soFar )) ) {
 				if ( match ) {
@@ -3825,9 +3826,9 @@
 				}
 				groups.push( tokens = [] );
 			}
-	
+
 			matched = false;
-	
+
 			// Combinators
 			if ( (match = rcombinators.exec( soFar )) ) {
 				matched = match.shift();
@@ -3838,7 +3839,7 @@
 				});
 				soFar = soFar.slice( matched.length );
 			}
-	
+
 			// Filters
 			for ( type in Expr.filter ) {
 				if ( (match = matchExpr[ type ].exec( soFar )) && (!preFilters[ type ] ||
@@ -3852,12 +3853,12 @@
 					soFar = soFar.slice( matched.length );
 				}
 			}
-	
+
 			if ( !matched ) {
 				break;
 			}
 		}
-	
+
 		// Return the length of the invalid excess
 		// if we're just parsing
 		// Otherwise, throw an error or return tokens
@@ -3868,7 +3869,7 @@
 				// Cache the tokens
 				tokenCache( selector, groups ).slice( 0 );
 	}
-	
+
 	function toSelector( tokens ) {
 		var i = 0,
 			len = tokens.length,
@@ -3878,12 +3879,12 @@
 		}
 		return selector;
 	}
-	
+
 	function addCombinator( matcher, combinator, base ) {
 		var dir = combinator.dir,
 			checkNonElements = base && dir === "parentNode",
 			doneName = done++;
-	
+
 		return combinator.first ?
 			// Check against closest ancestor/preceding element
 			function( elem, context, xml ) {
@@ -3893,12 +3894,12 @@
 					}
 				}
 			} :
-	
+
 			// Check against all ancestor/preceding elements
 			function( elem, context, xml ) {
 				var data, cache, outerCache,
 					dirkey = dirruns + " " + doneName;
-	
+
 				// We can't set arbitrary data on XML nodes, so they don't benefit from dir caching
 				if ( xml ) {
 					while ( (elem = elem[ dir ]) ) {
@@ -3928,7 +3929,7 @@
 				}
 			};
 	}
-	
+
 	function elementMatcher( matchers ) {
 		return matchers.length > 1 ?
 			function( elem, context, xml ) {
@@ -3942,14 +3943,14 @@
 			} :
 			matchers[0];
 	}
-	
+
 	function condense( unmatched, map, filter, context, xml ) {
 		var elem,
 			newUnmatched = [],
 			i = 0,
 			len = unmatched.length,
 			mapped = map != null;
-	
+
 		for ( ; i < len; i++ ) {
 			if ( (elem = unmatched[i]) ) {
 				if ( !filter || filter( elem, context, xml ) ) {
@@ -3960,10 +3961,10 @@
 				}
 			}
 		}
-	
+
 		return newUnmatched;
 	}
-	
+
 	function setMatcher( preFilter, selector, matcher, postFilter, postFinder, postSelector ) {
 		if ( postFilter && !postFilter[ expando ] ) {
 			postFilter = setMatcher( postFilter );
@@ -3976,36 +3977,36 @@
 				preMap = [],
 				postMap = [],
 				preexisting = results.length,
-	
+
 				// Get initial elements from seed or context
 				elems = seed || multipleContexts( selector || "*", context.nodeType ? [ context ] : context, [] ),
-	
+
 				// Prefilter to get matcher input, preserving a map for seed-results synchronization
 				matcherIn = preFilter && ( seed || !selector ) ?
 					condense( elems, preMap, preFilter, context, xml ) :
 					elems,
-	
+
 				matcherOut = matcher ?
 					// If we have a postFinder, or filtered seed, or non-seed postFilter or preexisting results,
 					postFinder || ( seed ? preFilter : preexisting || postFilter ) ?
-	
+
 						// ...intermediate processing is necessary
 						[] :
-	
+
 						// ...otherwise use results directly
 						results :
 					matcherIn;
-	
+
 			// Find primary matches
 			if ( matcher ) {
 				matcher( matcherIn, matcherOut, context, xml );
 			}
-	
+
 			// Apply postFilter
 			if ( postFilter ) {
 				temp = condense( matcherOut, postMap );
 				postFilter( temp, [], context, xml );
-	
+
 				// Un-match failing elements by moving them back to matcherIn
 				i = temp.length;
 				while ( i-- ) {
@@ -4014,7 +4015,7 @@
 					}
 				}
 			}
-	
+
 			if ( seed ) {
 				if ( postFinder || preFilter ) {
 					if ( postFinder ) {
@@ -4029,18 +4030,18 @@
 						}
 						postFinder( null, (matcherOut = []), temp, xml );
 					}
-	
+
 					// Move matched elements from seed to results to keep them synchronized
 					i = matcherOut.length;
 					while ( i-- ) {
 						if ( (elem = matcherOut[i]) &&
 							(temp = postFinder ? indexOf.call( seed, elem ) : preMap[i]) > -1 ) {
-	
+
 							seed[temp] = !(results[temp] = elem);
 						}
 					}
 				}
-	
+
 			// Add elements to results, through postFinder if defined
 			} else {
 				matcherOut = condense(
@@ -4056,14 +4057,14 @@
 			}
 		});
 	}
-	
+
 	function matcherFromTokens( tokens ) {
 		var checkContext, matcher, j,
 			len = tokens.length,
 			leadingRelative = Expr.relative[ tokens[0].type ],
 			implicitRelative = leadingRelative || Expr.relative[" "],
 			i = leadingRelative ? 1 : 0,
-	
+
 			// The foundational matcher ensures that elements are reachable from top-level context(s)
 			matchContext = addCombinator( function( elem ) {
 				return elem === checkContext;
@@ -4077,13 +4078,13 @@
 						matchContext( elem, context, xml ) :
 						matchAnyContext( elem, context, xml ) );
 			} ];
-	
+
 		for ( ; i < len; i++ ) {
 			if ( (matcher = Expr.relative[ tokens[i].type ]) ) {
 				matchers = [ addCombinator(elementMatcher( matchers ), matcher) ];
 			} else {
 				matcher = Expr.filter[ tokens[i].type ].apply( null, tokens[i].matches );
-	
+
 				// Return special upon seeing a positional matcher
 				if ( matcher[ expando ] ) {
 					// Find the next relative operator (if any) for proper handling
@@ -4108,10 +4109,10 @@
 				matchers.push( matcher );
 			}
 		}
-	
+
 		return elementMatcher( matchers );
 	}
-	
+
 	function matcherFromGroupMatchers( elementMatchers, setMatchers ) {
 		// A counter to specify which element is currently being matched
 		var matcherCachedRuns = 0,
@@ -4129,12 +4130,12 @@
 					elems = seed || byElement && Expr.find["TAG"]( "*", expandContext && context.parentNode || context ),
 					// Use integer dirruns iff this is the outermost matcher
 					dirrunsUnique = (dirruns += contextBackup == null ? 1 : Math.random() || 0.1);
-	
+
 				if ( outermost ) {
 					outermostContext = context !== document && context;
 					cachedruns = matcherCachedRuns;
 				}
-	
+
 				// Add elements passing elementMatchers directly to results
 				// Keep `i` a string if there are no elements so `matchedCount` will be "00" below
 				for ( ; (elem = elems[i]) != null; i++ ) {
@@ -4151,21 +4152,21 @@
 							cachedruns = ++matcherCachedRuns;
 						}
 					}
-	
+
 					// Track unmatched elements for set filters
 					if ( bySet ) {
 						// They will have gone through all possible matchers
 						if ( (elem = !matcher && elem) ) {
 							matchedCount--;
 						}
-	
+
 						// Lengthen the array for every element, matched or not
 						if ( seed ) {
 							unmatched.push( elem );
 						}
 					}
 				}
-	
+
 				// Apply set filters to unmatched elements
 				matchedCount += i;
 				if ( bySet && i !== matchedCount ) {
@@ -4173,7 +4174,7 @@
 					while ( (matcher = setMatchers[j++]) ) {
 						matcher( unmatched, setMatched, context, xml );
 					}
-	
+
 					if ( seed ) {
 						// Reintegrate element matches to eliminate the need for sorting
 						if ( matchedCount > 0 ) {
@@ -4183,42 +4184,42 @@
 								}
 							}
 						}
-	
+
 						// Discard index placeholder values to get only actual matches
 						setMatched = condense( setMatched );
 					}
-	
+
 					// Add matches to results
 					push.apply( results, setMatched );
-	
+
 					// Seedless set matches succeeding multiple successful matchers stipulate sorting
 					if ( outermost && !seed && setMatched.length > 0 &&
 						( matchedCount + setMatchers.length ) > 1 ) {
-	
+
 						Sizzle.uniqueSort( results );
 					}
 				}
-	
+
 				// Override manipulation of globals by nested matchers
 				if ( outermost ) {
 					dirruns = dirrunsUnique;
 					outermostContext = contextBackup;
 				}
-	
+
 				return unmatched;
 			};
-	
+
 		return bySet ?
 			markFunction( superMatcher ) :
 			superMatcher;
 	}
-	
+
 	compile = Sizzle.compile = function( selector, group /* Internal Use Only */ ) {
 		var i,
 			setMatchers = [],
 			elementMatchers = [],
 			cached = compilerCache[ selector + " " ];
-	
+
 		if ( !cached ) {
 			// Generate a function of recursive functions that can be used to check each element
 			if ( !group ) {
@@ -4233,13 +4234,13 @@
 					elementMatchers.push( cached );
 				}
 			}
-	
+
 			// Cache the compiled function
 			cached = compilerCache( selector, matcherFromGroupMatchers( elementMatchers, setMatchers ) );
 		}
 		return cached;
 	};
-	
+
 	function multipleContexts( selector, contexts, results ) {
 		var i = 0,
 			len = contexts.length;
@@ -4248,33 +4249,33 @@
 		}
 		return results;
 	}
-	
+
 	function select( selector, context, results, seed ) {
 		var i, tokens, token, type, find,
 			match = tokenize( selector );
-	
+
 		if ( !seed ) {
 			// Try to minimize operations if there is only one group
 			if ( match.length === 1 ) {
-	
+
 				// Take a shortcut and set the context if the root selector is an ID
 				tokens = match[0] = match[0].slice( 0 );
 				if ( tokens.length > 2 && (token = tokens[0]).type === "ID" &&
 						support.getById && context.nodeType === 9 && documentIsHTML &&
 						Expr.relative[ tokens[1].type ] ) {
-	
+
 					context = ( Expr.find["ID"]( token.matches[0].replace(runescape, funescape), context ) || [] )[0];
 					if ( !context ) {
 						return results;
 					}
 					selector = selector.slice( tokens.shift().value.length );
 				}
-	
+
 				// Fetch a seed set for right-to-left matching
 				i = matchExpr["needsContext"].test( selector ) ? 0 : tokens.length;
 				while ( i-- ) {
 					token = tokens[i];
-	
+
 					// Abort if we hit a combinator
 					if ( Expr.relative[ (type = token.type) ] ) {
 						break;
@@ -4285,7 +4286,7 @@
 							token.matches[0].replace( runescape, funescape ),
 							rsibling.test( tokens[0].type ) && context.parentNode || context
 						)) ) {
-	
+
 							// If seed is empty or no tokens remain, we can return early
 							tokens.splice( i, 1 );
 							selector = seed.length && toSelector( tokens );
@@ -4293,14 +4294,14 @@
 								push.apply( results, seed );
 								return results;
 							}
-	
+
 							break;
 						}
 					}
 				}
 			}
 		}
-	
+
 		// Compile and execute a filtering function
 		// Provide `match` to avoid retokenization if we modified the selector above
 		compile( selector, match )(
@@ -4312,26 +4313,26 @@
 		);
 		return results;
 	}
-	
+
 	// One-time assignments
-	
+
 	// Sort stability
 	support.sortStable = expando.split("").sort( sortOrder ).join("") === expando;
-	
+
 	// Support: Chrome<14
 	// Always assume duplicates if they aren't passed to the comparison function
 	support.detectDuplicates = hasDuplicate;
-	
+
 	// Initialize against the default document
 	setDocument();
-	
+
 	// Support: Webkit<537.32 - Safari 6.0.3/Chrome 25 (fixed in Chrome 27)
 	// Detached nodes confoundingly follow *each other*
 	support.sortDetached = assert(function( div1 ) {
 		// Should return 1, but returns 4 (following)
 		return div1.compareDocumentPosition( document.createElement("div") ) & 1;
 	});
-	
+
 	// Support: IE<8
 	// Prevent attribute/property "interpolation"
 	// http://msdn.microsoft.com/en-us/library/ms536429%28VS.85%29.aspx
@@ -4345,7 +4346,7 @@
 			}
 		});
 	}
-	
+
 	// Support: IE<9
 	// Use defaultValue in place of getAttribute("value")
 	if ( !support.attributes || !assert(function( div ) {
@@ -4359,7 +4360,7 @@
 			}
 		});
 	}
-	
+
 	// Support: IE<9
 	// Use getAttributeNode to fetch booleans when getAttribute lies
 	if ( !assert(function( div ) {
@@ -4374,7 +4375,7 @@
 			}
 		});
 	}
-	
+
 	jQuery.find = Sizzle;
 	jQuery.expr = Sizzle.selectors;
 	jQuery.expr[":"] = jQuery.expr.pseudos;
@@ -4382,12 +4383,12 @@
 	jQuery.text = Sizzle.getText;
 	jQuery.isXMLDoc = Sizzle.isXML;
 	jQuery.contains = Sizzle.contains;
-	
-	
+
+
 	})( window );
 	// String to Object options format cache
 	var optionsCache = {};
-	
+
 	// Convert String-formatted options into Object-formatted ones and store in cache
 	function createOptions( options ) {
 		var object = optionsCache[ options ] = {};
@@ -4396,7 +4397,7 @@
 		});
 		return object;
 	}
-	
+
 	/*
 	 * Create a callback list using the following parameters:
 	 *
@@ -4420,13 +4421,13 @@
 	 *
 	 */
 	jQuery.Callbacks = function( options ) {
-	
+
 		// Convert options from String-formatted to Object-formatted if needed
 		// (we check in cache first)
 		options = typeof options === "string" ?
 			( optionsCache[ options ] || createOptions( options ) ) :
 			jQuery.extend( {}, options );
-	
+
 		var // Last fire value (for non-forgettable lists)
 			memory,
 			// Flag to know if list was already fired
@@ -4579,11 +4580,11 @@
 					return !!fired;
 				}
 			};
-	
+
 		return self;
 	};
 	jQuery.extend({
-	
+
 		Deferred: function( func ) {
 			var tuples = [
 					// action, add listener, listener list, final state
@@ -4629,28 +4630,28 @@
 					}
 				},
 				deferred = {};
-	
+
 			// Keep pipe for back-compat
 			promise.pipe = promise.then;
-	
+
 			// Add list-specific methods
 			jQuery.each( tuples, function( i, tuple ) {
 				var list = tuple[ 2 ],
 					stateString = tuple[ 3 ];
-	
+
 				// promise[ done | fail | progress ] = list.add
 				promise[ tuple[1] ] = list.add;
-	
+
 				// Handle state
 				if ( stateString ) {
 					list.add(function() {
 						// state = [ resolved | rejected ]
 						state = stateString;
-	
+
 					// [ reject_list | resolve_list ].disable; progress_list.lock
 					}, tuples[ i ^ 1 ][ 2 ].disable, tuples[ 2 ][ 2 ].lock );
 				}
-	
+
 				// deferred[ resolve | reject | notify ]
 				deferred[ tuple[0] ] = function() {
 					deferred[ tuple[0] + "With" ]( this === deferred ? promise : this, arguments );
@@ -4658,31 +4659,31 @@
 				};
 				deferred[ tuple[0] + "With" ] = list.fireWith;
 			});
-	
+
 			// Make the deferred a promise
 			promise.promise( deferred );
-	
+
 			// Call given func if any
 			if ( func ) {
 				func.call( deferred, deferred );
 			}
-	
+
 			// All done!
 			return deferred;
 		},
-	
+
 		// Deferred helper
 		when: function( subordinate /* , ..., subordinateN */ ) {
 			var i = 0,
 				resolveValues = core_slice.call( arguments ),
 				length = resolveValues.length,
-	
+
 				// the count of uncompleted subordinates
 				remaining = length !== 1 || ( subordinate && jQuery.isFunction( subordinate.promise ) ) ? length : 0,
-	
+
 				// the master Deferred. If resolveValues consist of only a single Deferred, just use that.
 				deferred = remaining === 1 ? subordinate : jQuery.Deferred(),
-	
+
 				// Update function for both resolve and progress values
 				updateFunc = function( i, contexts, values ) {
 					return function( value ) {
@@ -4695,9 +4696,9 @@
 						}
 					};
 				},
-	
+
 				progressValues, progressContexts, resolveContexts;
-	
+
 			// add listeners to Deferred subordinates; treat others as resolved
 			if ( length > 1 ) {
 				progressValues = new Array( length );
@@ -4714,12 +4715,12 @@
 					}
 				}
 			}
-	
+
 			// if we're not waiting on anything, resolve the master
 			if ( !remaining ) {
 				deferred.resolveWith( resolveContexts, resolveValues );
 			}
-	
+
 			return deferred.promise();
 		}
 	});
@@ -4729,94 +4730,94 @@
 			div = document.createElement("div"),
 			select = document.createElement("select"),
 			opt = select.appendChild( document.createElement("option") );
-	
+
 		// Finish early in limited environments
 		if ( !input.type ) {
 			return support;
 		}
-	
+
 		input.type = "checkbox";
-	
+
 		// Support: Safari 5.1, iOS 5.1, Android 4.x, Android 2.3
 		// Check the default checkbox/radio value ("" on old WebKit; "on" elsewhere)
 		support.checkOn = input.value !== "";
-	
+
 		// Must access the parent to make an option select properly
 		// Support: IE9, IE10
 		support.optSelected = opt.selected;
-	
+
 		// Will be defined later
 		support.reliableMarginRight = true;
 		support.boxSizingReliable = true;
 		support.pixelPosition = false;
-	
+
 		// Make sure checked status is properly cloned
 		// Support: IE9, IE10
 		input.checked = true;
 		support.noCloneChecked = input.cloneNode( true ).checked;
-	
+
 		// Make sure that the options inside disabled selects aren't marked as disabled
 		// (WebKit marks them as disabled)
 		select.disabled = true;
 		support.optDisabled = !opt.disabled;
-	
+
 		// Check if an input maintains its value after becoming a radio
 		// Support: IE9, IE10
 		input = document.createElement("input");
 		input.value = "t";
 		input.type = "radio";
 		support.radioValue = input.value === "t";
-	
+
 		// #11217 - WebKit loses check when the name is after the checked attribute
 		input.setAttribute( "checked", "t" );
 		input.setAttribute( "name", "t" );
-	
+
 		fragment.appendChild( input );
-	
+
 		// Support: Safari 5.1, Android 4.x, Android 2.3
 		// old WebKit doesn't clone checked state correctly in fragments
 		support.checkClone = fragment.cloneNode( true ).cloneNode( true ).lastChild.checked;
-	
+
 		// Support: Firefox, Chrome, Safari
 		// Beware of CSP restrictions (https://developer.mozilla.org/en/Security/CSP)
 		support.focusinBubbles = "onfocusin" in window;
-	
+
 		div.style.backgroundClip = "content-box";
 		div.cloneNode( true ).style.backgroundClip = "";
 		support.clearCloneStyle = div.style.backgroundClip === "content-box";
-	
+
 		// Run tests that need a body at doc ready
 		jQuery(function() {
 			var container, marginDiv,
 				// Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
 				divReset = "padding:0;margin:0;border:0;display:block;-webkit-box-sizing:content-box;-moz-box-sizing:content-box;box-sizing:content-box",
 				body = document.getElementsByTagName("body")[ 0 ];
-	
+
 			if ( !body ) {
 				// Return for frameset docs that don't have a body
 				return;
 			}
-	
+
 			container = document.createElement("div");
 			container.style.cssText = "border:0;width:0;height:0;position:absolute;top:0;left:-9999px;margin-top:1px";
-	
+
 			// Check box-sizing and margin behavior.
 			body.appendChild( container ).appendChild( div );
 			div.innerHTML = "";
 			// Support: Firefox, Android 2.3 (Prefixed box-sizing versions).
 			div.style.cssText = "-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;padding:1px;border:1px;display:block;width:4px;margin-top:1%;position:absolute;top:1%";
-	
+
 			// Workaround failing boxSizing test due to offsetWidth returning wrong value
 			// with some non-1 values of body zoom, ticket #13543
 			jQuery.swap( body, body.style.zoom != null ? { zoom: 1 } : {}, function() {
 				support.boxSizing = div.offsetWidth === 4;
 			});
-	
+
 			// Use window.getComputedStyle because jsdom on node.js will break without it.
 			if ( window.getComputedStyle ) {
 				support.pixelPosition = ( window.getComputedStyle( div, null ) || {} ).top !== "1%";
 				support.boxSizingReliable = ( window.getComputedStyle( div, null ) || { width: "4px" } ).width === "4px";
-	
+
 				// Support: Android 2.3
 				// Check if div with explicit width and no margin-right incorrectly
 				// gets computed margin-right based on width of container. (#3333)
@@ -4825,20 +4826,20 @@
 				marginDiv.style.cssText = div.style.cssText = divReset;
 				marginDiv.style.marginRight = marginDiv.style.width = "0";
 				div.style.width = "1px";
-	
+
 				support.reliableMarginRight =
 					!parseFloat( ( window.getComputedStyle( marginDiv, null ) || {} ).marginRight );
 			}
-	
+
 			body.removeChild( container );
 		});
-	
+
 		return support;
 	})( {} );
-	
+
 	/*
 		Implementation Summary
-	
+
 		1. Enforce API surface and semantic compatibility with 1.9.x branch
 		2. Improve the module's maintainability by reducing the storage
 			paths to a single mechanism.
@@ -4850,7 +4851,7 @@
 	var data_user, data_priv,
 		rbrace = /(?:\{[\s\S]*\}|\[[\s\S]*\])$/,
 		rmultiDash = /([A-Z])/g;
-	
+
 	function Data() {
 		// Support: Android < 4,
 		// Old WebKit does not have Object.preventExtensions/freeze method,
@@ -4860,12 +4861,12 @@
 				return {};
 			}
 		});
-	
+
 		this.expando = jQuery.expando + Math.random();
 	}
-	
+
 	Data.uid = 1;
-	
+
 	Data.accepts = function( owner ) {
 		// Accepts only:
 		//  - Node
@@ -4876,7 +4877,7 @@
 		return owner.nodeType ?
 			owner.nodeType === 1 || owner.nodeType === 9 : true;
 	};
-	
+
 	Data.prototype = {
 		key: function( owner ) {
 			// We can accept data for non-element nodes in modern browsers,
@@ -4885,20 +4886,20 @@
 			if ( !Data.accepts( owner ) ) {
 				return 0;
 			}
-	
+
 			var descriptor = {},
 				// Check if the owner object already has a cache key
 				unlock = owner[ this.expando ];
-	
+
 			// If not, create one
 			if ( !unlock ) {
 				unlock = Data.uid++;
-	
+
 				// Secure it in a non-enumerable, non-writable property
 				try {
 					descriptor[ this.expando ] = { value: unlock };
 					Object.defineProperties( owner, descriptor );
-	
+
 				// Support: Android < 4
 				// Fallback to a less secure definition
 				} catch ( e ) {
@@ -4906,12 +4907,12 @@
 					jQuery.extend( owner, descriptor );
 				}
 			}
-	
+
 			// Ensure the cache object
 			if ( !this.cache[ unlock ] ) {
 				this.cache[ unlock ] = {};
 			}
-	
+
 			return unlock;
 		},
 		set: function( owner, data, value ) {
@@ -4921,11 +4922,11 @@
 				// and set the unlock as though an owner entry had always existed
 				unlock = this.key( owner ),
 				cache = this.cache[ unlock ];
-	
+
 			// Handle: [ owner, key, value ] args
 			if ( typeof data === "string" ) {
 				cache[ data ] = value;
-	
+
 			// Handle: [ owner, { properties } ] args
 			} else {
 				// Fresh assignments by object are shallow copied
@@ -4946,7 +4947,7 @@
 			// allowing direct access to the newly created
 			// empty data object. A valid owner object must be provided.
 			var cache = this.cache[ this.key( owner ) ];
-	
+
 			return key === undefined ?
 				cache : cache[ key ];
 		},
@@ -4965,13 +4966,13 @@
 			//
 			if ( key === undefined ||
 					((key && typeof key === "string") && value === undefined) ) {
-	
+
 				stored = this.get( owner, key );
-	
+
 				return stored !== undefined ?
 					stored : this.get( owner, jQuery.camelCase(key) );
 			}
-	
+
 			// [*]When the key is not a string, or both a key and value
 			// are specified, set or extend (existing objects) with either:
 			//
@@ -4979,7 +4980,7 @@
 			//   2. A key and value
 			//
 			this.set( owner, key, value );
-	
+
 			// Since the "set" path can have two possible entry points
 			// return the expected data based on which path was taken[*]
 			return value !== undefined ? value : key;
@@ -4988,10 +4989,10 @@
 			var i, name, camel,
 				unlock = this.key( owner ),
 				cache = this.cache[ unlock ];
-	
+
 			if ( key === undefined ) {
 				this.cache[ unlock ] = {};
-	
+
 			} else {
 				// Support array or space separated string of keys
 				if ( jQuery.isArray( key ) ) {
@@ -5015,7 +5016,7 @@
 							[ name ] : ( name.match( core_rnotwhite ) || [] );
 					}
 				}
-	
+
 				i = name.length;
 				while ( i-- ) {
 					delete cache[ name[ i ] ];
@@ -5033,55 +5034,55 @@
 			}
 		}
 	};
-	
+
 	// These may be used throughout the jQuery core codebase
 	data_user = new Data();
 	data_priv = new Data();
-	
-	
+
+
 	jQuery.extend({
 		acceptData: Data.accepts,
-	
+
 		hasData: function( elem ) {
 			return data_user.hasData( elem ) || data_priv.hasData( elem );
 		},
-	
+
 		data: function( elem, name, data ) {
 			return data_user.access( elem, name, data );
 		},
-	
+
 		removeData: function( elem, name ) {
 			data_user.remove( elem, name );
 		},
-	
+
 		// TODO: Now that all calls to _data and _removeData have been replaced
 		// with direct calls to data_priv methods, these can be deprecated.
 		_data: function( elem, name, data ) {
 			return data_priv.access( elem, name, data );
 		},
-	
+
 		_removeData: function( elem, name ) {
 			data_priv.remove( elem, name );
 		}
 	});
-	
+
 	jQuery.fn.extend({
 		data: function( key, value ) {
 			var attrs, name,
 				elem = this[ 0 ],
 				i = 0,
 				data = null;
-	
+
 			// Gets all values
 			if ( key === undefined ) {
 				if ( this.length ) {
 					data = data_user.get( elem );
-	
+
 					if ( elem.nodeType === 1 && !data_priv.get( elem, "hasDataAttrs" ) ) {
 						attrs = elem.attributes;
 						for ( ; i < attrs.length; i++ ) {
 							name = attrs[ i ].name;
-	
+
 							if ( name.indexOf( "data-" ) === 0 ) {
 								name = jQuery.camelCase( name.slice(5) );
 								dataAttr( elem, name, data[ name ] );
@@ -5090,21 +5091,21 @@
 						data_priv.set( elem, "hasDataAttrs", true );
 					}
 				}
-	
+
 				return data;
 			}
-	
+
 			// Sets multiple values
 			if ( typeof key === "object" ) {
 				return this.each(function() {
 					data_user.set( this, key );
 				});
 			}
-	
+
 			return jQuery.access( this, function( value ) {
 				var data,
 					camelKey = jQuery.camelCase( key );
-	
+
 				// The calling jQuery object (element matches) is not empty
 				// (and therefore has an element appears at this[ 0 ]) and the
 				// `value` parameter was not undefined. An empty jQuery object
@@ -5117,36 +5118,36 @@
 					if ( data !== undefined ) {
 						return data;
 					}
-	
+
 					// Attempt to get data from the cache
 					// with the key camelized
 					data = data_user.get( elem, camelKey );
 					if ( data !== undefined ) {
 						return data;
 					}
-	
+
 					// Attempt to "discover" the data in
 					// HTML5 custom data-* attrs
 					data = dataAttr( elem, camelKey, undefined );
 					if ( data !== undefined ) {
 						return data;
 					}
-	
+
 					// We tried really hard, but the data doesn't exist.
 					return;
 				}
-	
+
 				// Set the data...
 				this.each(function() {
 					// First, attempt to store a copy or reference of any
 					// data that might've been store with a camelCased key.
 					var data = data_user.get( this, camelKey );
-	
+
 					// For HTML5 data-* attribute interop, we have to
 					// store property names with dashes in a camelCase form.
 					// This might not apply to all properties...*
 					data_user.set( this, camelKey, value );
-	
+
 					// *... In the case of properties that might _actually_
 					// have dashes, we need to also store a copy of that
 					// unchanged property.
@@ -5156,23 +5157,23 @@
 				});
 			}, null, value, arguments.length > 1, null, true );
 		},
-	
+
 		removeData: function( key ) {
 			return this.each(function() {
 				data_user.remove( this, key );
 			});
 		}
 	});
-	
+
 	function dataAttr( elem, key, data ) {
 		var name;
-	
+
 		// If nothing was found internally, try to fetch any
 		// data from the HTML5 data-* attribute
 		if ( data === undefined && elem.nodeType === 1 ) {
 			name = "data-" + key.replace( rmultiDash, "-$1" ).toLowerCase();
 			data = elem.getAttribute( name );
-	
+
 			if ( typeof data === "string" ) {
 				try {
 					data = data === "true" ? true :
@@ -5183,7 +5184,7 @@
 						rbrace.test( data ) ? JSON.parse( data ) :
 						data;
 				} catch( e ) {}
-	
+
 				// Make sure we set the data so it isn't changed later
 				data_user.set( elem, key, data );
 			} else {
@@ -5195,11 +5196,11 @@
 	jQuery.extend({
 		queue: function( elem, type, data ) {
 			var queue;
-	
+
 			if ( elem ) {
 				type = ( type || "fx" ) + "queue";
 				queue = data_priv.get( elem, type );
-	
+
 				// Speed up dequeue by getting out quickly if this is just a lookup
 				if ( data ) {
 					if ( !queue || jQuery.isArray( data ) ) {
@@ -5211,10 +5212,10 @@
 				return queue || [];
 			}
 		},
-	
+
 		dequeue: function( elem, type ) {
 			type = type || "fx";
-	
+
 			var queue = jQuery.queue( elem, type ),
 				startLength = queue.length,
 				fn = queue.shift(),
@@ -5222,31 +5223,31 @@
 				next = function() {
 					jQuery.dequeue( elem, type );
 				};
-	
+
 			// If the fx queue is dequeued, always remove the progress sentinel
 			if ( fn === "inprogress" ) {
 				fn = queue.shift();
 				startLength--;
 			}
-	
+
 			if ( fn ) {
-	
+
 				// Add a progress sentinel to prevent the fx queue from being
 				// automatically dequeued
 				if ( type === "fx" ) {
 					queue.unshift( "inprogress" );
 				}
-	
+
 				// clear up the last queue stop function
 				delete hooks.stop;
 				fn.call( elem, next, hooks );
 			}
-	
+
 			if ( !startLength && hooks ) {
 				hooks.empty.fire();
 			}
 		},
-	
+
 		// not intended for public consumption - generates a queueHooks object, or returns the current one
 		_queueHooks: function( elem, type ) {
 			var key = type + "queueHooks";
@@ -5257,29 +5258,29 @@
 			});
 		}
 	});
-	
+
 	jQuery.fn.extend({
 		queue: function( type, data ) {
 			var setter = 2;
-	
+
 			if ( typeof type !== "string" ) {
 				data = type;
 				type = "fx";
 				setter--;
 			}
-	
+
 			if ( arguments.length < setter ) {
 				return jQuery.queue( this[0], type );
 			}
-	
+
 			return data === undefined ?
 				this :
 				this.each(function() {
 					var queue = jQuery.queue( this, type, data );
-	
+
 					// ensure a hooks for this queue
 					jQuery._queueHooks( this, type );
-	
+
 					if ( type === "fx" && queue[0] !== "inprogress" ) {
 						jQuery.dequeue( this, type );
 					}
@@ -5295,7 +5296,7 @@
 		delay: function( time, type ) {
 			time = jQuery.fx ? jQuery.fx.speeds[ time ] || time : time;
 			type = type || "fx";
-	
+
 			return this.queue( type, function( next, hooks ) {
 				var timeout = setTimeout( next, time );
 				hooks.stop = function() {
@@ -5319,13 +5320,13 @@
 						defer.resolveWith( elements, [ elements ] );
 					}
 				};
-	
+
 			if ( typeof type !== "string" ) {
 				obj = type;
 				type = undefined;
 			}
 			type = type || "fx";
-	
+
 			while( i-- ) {
 				tmp = data_priv.get( elements[ i ], type + "queueHooks" );
 				if ( tmp && tmp.empty ) {
@@ -5341,51 +5342,51 @@
 		rclass = /[\t\r\n\f]/g,
 		rreturn = /\r/g,
 		rfocusable = /^(?:input|select|textarea|button)$/i;
-	
+
 	jQuery.fn.extend({
 		attr: function( name, value ) {
 			return jQuery.access( this, jQuery.attr, name, value, arguments.length > 1 );
 		},
-	
+
 		removeAttr: function( name ) {
 			return this.each(function() {
 				jQuery.removeAttr( this, name );
 			});
 		},
-	
+
 		prop: function( name, value ) {
 			return jQuery.access( this, jQuery.prop, name, value, arguments.length > 1 );
 		},
-	
+
 		removeProp: function( name ) {
 			return this.each(function() {
 				delete this[ jQuery.propFix[ name ] || name ];
 			});
 		},
-	
+
 		addClass: function( value ) {
 			var classes, elem, cur, clazz, j,
 				i = 0,
 				len = this.length,
 				proceed = typeof value === "string" && value;
-	
+
 			if ( jQuery.isFunction( value ) ) {
 				return this.each(function( j ) {
 					jQuery( this ).addClass( value.call( this, j, this.className ) );
 				});
 			}
-	
+
 			if ( proceed ) {
 				// The disjunction here is for better compressibility (see removeClass)
 				classes = ( value || "" ).match( core_rnotwhite ) || [];
-	
+
 				for ( ; i < len; i++ ) {
 					elem = this[ i ];
 					cur = elem.nodeType === 1 && ( elem.className ?
 						( " " + elem.className + " " ).replace( rclass, " " ) :
 						" "
 					);
-	
+
 					if ( cur ) {
 						j = 0;
 						while ( (clazz = classes[j++]) ) {
@@ -5394,20 +5395,20 @@
 							}
 						}
 						elem.className = jQuery.trim( cur );
-	
+
 					}
 				}
 			}
-	
+
 			return this;
 		},
-	
+
 		removeClass: function( value ) {
 			var classes, elem, cur, clazz, j,
 				i = 0,
 				len = this.length,
 				proceed = arguments.length === 0 || typeof value === "string" && value;
-	
+
 			if ( jQuery.isFunction( value ) ) {
 				return this.each(function( j ) {
 					jQuery( this ).removeClass( value.call( this, j, this.className ) );
@@ -5415,7 +5416,7 @@
 			}
 			if ( proceed ) {
 				classes = ( value || "" ).match( core_rnotwhite ) || [];
-	
+
 				for ( ; i < len; i++ ) {
 					elem = this[ i ];
 					// This expression is here for better compressibility (see addClass)
@@ -5423,7 +5424,7 @@
 						( " " + elem.className + " " ).replace( rclass, " " ) :
 						""
 					);
-	
+
 					if ( cur ) {
 						j = 0;
 						while ( (clazz = classes[j++]) ) {
@@ -5436,23 +5437,23 @@
 					}
 				}
 			}
-	
+
 			return this;
 		},
-	
+
 		toggleClass: function( value, stateVal ) {
 			var type = typeof value;
-	
+
 			if ( typeof stateVal === "boolean" && type === "string" ) {
 				return stateVal ? this.addClass( value ) : this.removeClass( value );
 			}
-	
+
 			if ( jQuery.isFunction( value ) ) {
 				return this.each(function( i ) {
 					jQuery( this ).toggleClass( value.call(this, i, this.className, stateVal), stateVal );
 				});
 			}
-	
+
 			return this.each(function() {
 				if ( type === "string" ) {
 					// toggle individual class names
@@ -5460,7 +5461,7 @@
 						i = 0,
 						self = jQuery( this ),
 						classNames = value.match( core_rnotwhite ) || [];
-	
+
 					while ( (className = classNames[ i++ ]) ) {
 						// check each className given, space separated list
 						if ( self.hasClass( className ) ) {
@@ -5469,14 +5470,14 @@
 							self.addClass( className );
 						}
 					}
-	
+
 				// Toggle whole class name
 				} else if ( type === core_strundefined || type === "boolean" ) {
 					if ( this.className ) {
 						// store className if set
 						data_priv.set( this, "__className__", this.className );
 					}
-	
+
 					// If the element has a class name or if we're passed "false",
 					// then remove the whole classname (if there was one, the above saved it).
 					// Otherwise bring back whatever was previously saved (if anything),
@@ -5485,7 +5486,7 @@
 				}
 			});
 		},
-	
+
 		hasClass: function( selector ) {
 			var className = " " + selector + " ",
 				i = 0,
@@ -5495,49 +5496,49 @@
 					return true;
 				}
 			}
-	
+
 			return false;
 		},
-	
+
 		val: function( value ) {
 			var hooks, ret, isFunction,
 				elem = this[0];
-	
+
 			if ( !arguments.length ) {
 				if ( elem ) {
 					hooks = jQuery.valHooks[ elem.type ] || jQuery.valHooks[ elem.nodeName.toLowerCase() ];
-	
+
 					if ( hooks && "get" in hooks && (ret = hooks.get( elem, "value" )) !== undefined ) {
 						return ret;
 					}
-	
+
 					ret = elem.value;
-	
+
 					return typeof ret === "string" ?
 						// handle most common string cases
 						ret.replace(rreturn, "") :
 						// handle cases where value is null/undef or number
 						ret == null ? "" : ret;
 				}
-	
+
 				return;
 			}
-	
+
 			isFunction = jQuery.isFunction( value );
-	
+
 			return this.each(function( i ) {
 				var val;
-	
+
 				if ( this.nodeType !== 1 ) {
 					return;
 				}
-	
+
 				if ( isFunction ) {
 					val = value.call( this, i, jQuery( this ).val() );
 				} else {
 					val = value;
 				}
-	
+
 				// Treat null/undefined as ""; convert numbers to string
 				if ( val == null ) {
 					val = "";
@@ -5548,9 +5549,9 @@
 						return value == null ? "" : value + "";
 					});
 				}
-	
+
 				hooks = jQuery.valHooks[ this.type ] || jQuery.valHooks[ this.nodeName.toLowerCase() ];
-	
+
 				// If set returns undefined, fall back to normal setting
 				if ( !hooks || !("set" in hooks) || hooks.set( this, val, "value" ) === undefined ) {
 					this.value = val;
@@ -5558,7 +5559,7 @@
 			});
 		}
 	});
-	
+
 	jQuery.extend({
 		valHooks: {
 			option: {
@@ -5580,46 +5581,46 @@
 						i = index < 0 ?
 							max :
 							one ? index : 0;
-	
+
 					// Loop through all the selected options
 					for ( ; i < max; i++ ) {
 						option = options[ i ];
-	
+
 						// IE6-9 doesn't update selected after form reset (#2551)
 						if ( ( option.selected || i === index ) &&
 								// Don't return options that are disabled or in a disabled optgroup
 								( jQuery.support.optDisabled ? !option.disabled : option.getAttribute("disabled") === null ) &&
 								( !option.parentNode.disabled || !jQuery.nodeName( option.parentNode, "optgroup" ) ) ) {
-	
+
 							// Get the specific value for the option
 							value = jQuery( option ).val();
-	
+
 							// We don't need an array for one selects
 							if ( one ) {
 								return value;
 							}
-	
+
 							// Multi-Selects return an array
 							values.push( value );
 						}
 					}
-	
+
 					return values;
 				},
-	
+
 				set: function( elem, value ) {
 					var optionSet, option,
 						options = elem.options,
 						values = jQuery.makeArray( value ),
 						i = options.length;
-	
+
 					while ( i-- ) {
 						option = options[ i ];
 						if ( (option.selected = jQuery.inArray( jQuery(option).val(), values ) >= 0) ) {
 							optionSet = true;
 						}
 					}
-	
+
 					// force browsers to behave consistently when non-matching value is set
 					if ( !optionSet ) {
 						elem.selectedIndex = -1;
@@ -5628,21 +5629,21 @@
 				}
 			}
 		},
-	
+
 		attr: function( elem, name, value ) {
 			var hooks, ret,
 				nType = elem.nodeType;
-	
+
 			// don't get/set attributes on text, comment and attribute nodes
 			if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
 				return;
 			}
-	
+
 			// Fallback to prop when attributes are not supported
 			if ( typeof elem.getAttribute === core_strundefined ) {
 				return jQuery.prop( elem, name, value );
 			}
-	
+
 			// All attributes are lowercase
 			// Grab necessary hook if one is defined
 			if ( nType !== 1 || !jQuery.isXMLDoc( elem ) ) {
@@ -5650,53 +5651,53 @@
 				hooks = jQuery.attrHooks[ name ] ||
 					( jQuery.expr.match.bool.test( name ) ? boolHook : nodeHook );
 			}
-	
+
 			if ( value !== undefined ) {
-	
+
 				if ( value === null ) {
 					jQuery.removeAttr( elem, name );
-	
+
 				} else if ( hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ) {
 					return ret;
-	
+
 				} else {
 					elem.setAttribute( name, value + "" );
 					return value;
 				}
-	
+
 			} else if ( hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ) {
 				return ret;
-	
+
 			} else {
 				ret = jQuery.find.attr( elem, name );
-	
+
 				// Non-existent attributes return null, we normalize to undefined
 				return ret == null ?
 					undefined :
 					ret;
 			}
 		},
-	
+
 		removeAttr: function( elem, value ) {
 			var name, propName,
 				i = 0,
 				attrNames = value && value.match( core_rnotwhite );
-	
+
 			if ( attrNames && elem.nodeType === 1 ) {
 				while ( (name = attrNames[i++]) ) {
 					propName = jQuery.propFix[ name ] || name;
-	
+
 					// Boolean attributes get special treatment (#10870)
 					if ( jQuery.expr.match.bool.test( name ) ) {
 						// Set corresponding property to false
 						elem[ propName ] = false;
 					}
-	
+
 					elem.removeAttribute( name );
 				}
 			}
 		},
-	
+
 		attrHooks: {
 			type: {
 				set: function( elem, value ) {
@@ -5713,41 +5714,41 @@
 				}
 			}
 		},
-	
+
 		propFix: {
 			"for": "htmlFor",
 			"class": "className"
 		},
-	
+
 		prop: function( elem, name, value ) {
 			var ret, hooks, notxml,
 				nType = elem.nodeType;
-	
+
 			// don't get/set properties on text, comment and attribute nodes
 			if ( !elem || nType === 3 || nType === 8 || nType === 2 ) {
 				return;
 			}
-	
+
 			notxml = nType !== 1 || !jQuery.isXMLDoc( elem );
-	
+
 			if ( notxml ) {
 				// Fix name and attach hooks
 				name = jQuery.propFix[ name ] || name;
 				hooks = jQuery.propHooks[ name ];
 			}
-	
+
 			if ( value !== undefined ) {
 				return hooks && "set" in hooks && (ret = hooks.set( elem, value, name )) !== undefined ?
 					ret :
 					( elem[ name ] = value );
-	
+
 			} else {
 				return hooks && "get" in hooks && (ret = hooks.get( elem, name )) !== null ?
 					ret :
 					elem[ name ];
 			}
 		},
-	
+
 		propHooks: {
 			tabIndex: {
 				get: function( elem ) {
@@ -5758,7 +5759,7 @@
 			}
 		}
 	});
-	
+
 	// Hooks for boolean attributes
 	boolHook = {
 		set: function( elem, value, name ) {
@@ -5773,7 +5774,7 @@
 	};
 	jQuery.each( jQuery.expr.match.bool.source.match( /\w+/g ), function( i, name ) {
 		var getter = jQuery.expr.attrHandle[ name ] || jQuery.find.attr;
-	
+
 		jQuery.expr.attrHandle[ name ] = function( elem, name, isXML ) {
 			var fn = jQuery.expr.attrHandle[ name ],
 				ret = isXML ?
@@ -5782,17 +5783,17 @@
 					// Temporarily disable this handler to check existence
 					(jQuery.expr.attrHandle[ name ] = undefined) !=
 						getter( elem, name, isXML ) ?
-	
+
 						name.toLowerCase() :
 						null;
-	
+
 			// Restore handler
 			jQuery.expr.attrHandle[ name ] = fn;
-	
+
 			return ret;
 		};
 	});
-	
+
 	// Support: IE9+
 	// Selectedness for an option in an optgroup can be inaccurate
 	if ( !jQuery.support.optSelected ) {
@@ -5806,7 +5807,7 @@
 			}
 		};
 	}
-	
+
 	jQuery.each([
 		"tabIndex",
 		"readOnly",
@@ -5821,7 +5822,7 @@
 	], function() {
 		jQuery.propFix[ this.toLowerCase() ] = this;
 	});
-	
+
 	// Radios and checkboxes getter/setter
 	jQuery.each([ "radio", "checkbox" ], function() {
 		jQuery.valHooks[ this ] = {
@@ -5843,53 +5844,53 @@
 		rmouseEvent = /^(?:mouse|contextmenu)|click/,
 		rfocusMorph = /^(?:focusinfocus|focusoutblur)$/,
 		rtypenamespace = /^([^.]*)(?:\.(.+)|)$/;
-	
+
 	function returnTrue() {
 		return true;
 	}
-	
+
 	function returnFalse() {
 		return false;
 	}
-	
+
 	function safeActiveElement() {
 		try {
 			return document.activeElement;
 		} catch ( err ) { }
 	}
-	
+
 	/*
 	 * Helper functions for managing events -- not part of the public interface.
 	 * Props to Dean Edwards' addEvent library for many of the ideas.
 	 */
 	jQuery.event = {
-	
+
 		global: {},
-	
+
 		add: function( elem, types, handler, data, selector ) {
-	
+
 			var handleObjIn, eventHandle, tmp,
 				events, t, handleObj,
 				special, handlers, type, namespaces, origType,
 				elemData = data_priv.get( elem );
-	
+
 			// Don't attach events to noData or text/comment nodes (but allow plain objects)
 			if ( !elemData ) {
 				return;
 			}
-	
+
 			// Caller can pass in an object of custom data in lieu of the handler
 			if ( handler.handler ) {
 				handleObjIn = handler;
 				handler = handleObjIn.handler;
 				selector = handleObjIn.selector;
 			}
-	
+
 			// Make sure that the handler has a unique ID, used to find/remove it later
 			if ( !handler.guid ) {
 				handler.guid = jQuery.guid++;
 			}
-	
+
 			// Init the element's event structure and main handler, if this is the first
 			if ( !(events = elemData.events) ) {
 				events = elemData.events = {};
@@ -5905,7 +5906,7 @@
 				// Add elem as a property of the handle fn to prevent a memory leak with IE non-native events
 				eventHandle.elem = elem;
 			}
-	
+
 			// Handle multiple events separated by a space
 			types = ( types || "" ).match( core_rnotwhite ) || [""];
 			t = types.length;
@@ -5913,21 +5914,21 @@
 				tmp = rtypenamespace.exec( types[t] ) || [];
 				type = origType = tmp[1];
 				namespaces = ( tmp[2] || "" ).split( "." ).sort();
-	
+
 				// There *must* be a type, no attaching namespace-only handlers
 				if ( !type ) {
 					continue;
 				}
-	
+
 				// If event changes its type, use the special event handlers for the changed type
 				special = jQuery.event.special[ type ] || {};
-	
+
 				// If selector defined, determine special event api type, otherwise given type
 				type = ( selector ? special.delegateType : special.bindType ) || type;
-	
+
 				// Update special based on newly reset type
 				special = jQuery.event.special[ type ] || {};
-	
+
 				// handleObj is passed to all event handlers
 				handleObj = jQuery.extend({
 					type: type,
@@ -5939,12 +5940,12 @@
 					needsContext: selector && jQuery.expr.match.needsContext.test( selector ),
 					namespace: namespaces.join(".")
 				}, handleObjIn );
-	
+
 				// Init the event handler queue if we're the first
 				if ( !(handlers = events[ type ]) ) {
 					handlers = events[ type ] = [];
 					handlers.delegateCount = 0;
-	
+
 					// Only use addEventListener if the special events handler returns false
 					if ( !special.setup || special.setup.call( elem, data, namespaces, eventHandle ) === false ) {
 						if ( elem.addEventListener ) {
@@ -5952,42 +5953,42 @@
 						}
 					}
 				}
-	
+
 				if ( special.add ) {
 					special.add.call( elem, handleObj );
-	
+
 					if ( !handleObj.handler.guid ) {
 						handleObj.handler.guid = handler.guid;
 					}
 				}
-	
+
 				// Add to the element's handler list, delegates in front
 				if ( selector ) {
 					handlers.splice( handlers.delegateCount++, 0, handleObj );
 				} else {
 					handlers.push( handleObj );
 				}
-	
+
 				// Keep track of which events have ever been used, for event optimization
 				jQuery.event.global[ type ] = true;
 			}
-	
+
 			// Nullify elem to prevent memory leaks in IE
 			elem = null;
 		},
-	
+
 		// Detach an event or set of events from an element
 		remove: function( elem, types, handler, selector, mappedTypes ) {
-	
+
 			var j, origCount, tmp,
 				events, t, handleObj,
 				special, handlers, type, namespaces, origType,
 				elemData = data_priv.hasData( elem ) && data_priv.get( elem );
-	
+
 			if ( !elemData || !(events = elemData.events) ) {
 				return;
 			}
-	
+
 			// Once for each type.namespace in types; type may be omitted
 			types = ( types || "" ).match( core_rnotwhite ) || [""];
 			t = types.length;
@@ -5995,7 +5996,7 @@
 				tmp = rtypenamespace.exec( types[t] ) || [];
 				type = origType = tmp[1];
 				namespaces = ( tmp[2] || "" ).split( "." ).sort();
-	
+
 				// Unbind all events (on this namespace, if provided) for the element
 				if ( !type ) {
 					for ( type in events ) {
@@ -6003,23 +6004,23 @@
 					}
 					continue;
 				}
-	
+
 				special = jQuery.event.special[ type ] || {};
 				type = ( selector ? special.delegateType : special.bindType ) || type;
 				handlers = events[ type ] || [];
 				tmp = tmp[2] && new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" );
-	
+
 				// Remove matching events
 				origCount = j = handlers.length;
 				while ( j-- ) {
 					handleObj = handlers[ j ];
-	
+
 					if ( ( mappedTypes || origType === handleObj.origType ) &&
 						( !handler || handler.guid === handleObj.guid ) &&
 						( !tmp || tmp.test( handleObj.namespace ) ) &&
 						( !selector || selector === handleObj.selector || selector === "**" && handleObj.selector ) ) {
 						handlers.splice( j, 1 );
-	
+
 						if ( handleObj.selector ) {
 							handlers.delegateCount--;
 						}
@@ -6028,44 +6029,44 @@
 						}
 					}
 				}
-	
+
 				// Remove generic event handler if we removed something and no more handlers exist
 				// (avoids potential for endless recursion during removal of special event handlers)
 				if ( origCount && !handlers.length ) {
 					if ( !special.teardown || special.teardown.call( elem, namespaces, elemData.handle ) === false ) {
 						jQuery.removeEvent( elem, type, elemData.handle );
 					}
-	
+
 					delete events[ type ];
 				}
 			}
-	
+
 			// Remove the expando if it's no longer used
 			if ( jQuery.isEmptyObject( events ) ) {
 				delete elemData.handle;
 				data_priv.remove( elem, "events" );
 			}
 		},
-	
+
 		trigger: function( event, data, elem, onlyHandlers ) {
-	
+
 			var i, cur, tmp, bubbleType, ontype, handle, special,
 				eventPath = [ elem || document ],
 				type = core_hasOwn.call( event, "type" ) ? event.type : event,
 				namespaces = core_hasOwn.call( event, "namespace" ) ? event.namespace.split(".") : [];
-	
+
 			cur = tmp = elem = elem || document;
-	
+
 			// Don't do events on text and comment nodes
 			if ( elem.nodeType === 3 || elem.nodeType === 8 ) {
 				return;
 			}
-	
+
 			// focus/blur morphs to focusin/out; ensure we're not firing them right now
 			if ( rfocusMorph.test( type + jQuery.event.triggered ) ) {
 				return;
 			}
-	
+
 			if ( type.indexOf(".") >= 0 ) {
 				// Namespaced trigger; create a regexp to match event type in handle()
 				namespaces = type.split(".");
@@ -6073,40 +6074,40 @@
 				namespaces.sort();
 			}
 			ontype = type.indexOf(":") < 0 && "on" + type;
-	
+
 			// Caller can pass in a jQuery.Event object, Object, or just an event type string
 			event = event[ jQuery.expando ] ?
 				event :
 				new jQuery.Event( type, typeof event === "object" && event );
-	
+
 			// Trigger bitmask: & 1 for native handlers; & 2 for jQuery (always true)
 			event.isTrigger = onlyHandlers ? 2 : 3;
 			event.namespace = namespaces.join(".");
 			event.namespace_re = event.namespace ?
 				new RegExp( "(^|\\.)" + namespaces.join("\\.(?:.*\\.|)") + "(\\.|$)" ) :
 				null;
-	
+
 			// Clean up the event in case it is being reused
 			event.result = undefined;
 			if ( !event.target ) {
 				event.target = elem;
 			}
-	
+
 			// Clone any incoming data and prepend the event, creating the handler arg list
 			data = data == null ?
 				[ event ] :
 				jQuery.makeArray( data, [ event ] );
-	
+
 			// Allow special events to draw outside the lines
 			special = jQuery.event.special[ type ] || {};
 			if ( !onlyHandlers && special.trigger && special.trigger.apply( elem, data ) === false ) {
 				return;
 			}
-	
+
 			// Determine event propagation path in advance, per W3C events spec (#9951)
 			// Bubble up to document, then to window; watch for a global ownerDocument var (#9724)
 			if ( !onlyHandlers && !special.noBubble && !jQuery.isWindow( elem ) ) {
-	
+
 				bubbleType = special.delegateType || type;
 				if ( !rfocusMorph.test( bubbleType + type ) ) {
 					cur = cur.parentNode;
@@ -6115,27 +6116,27 @@
 					eventPath.push( cur );
 					tmp = cur;
 				}
-	
+
 				// Only add window if we got to document (e.g., not plain obj or detached DOM)
 				if ( tmp === (elem.ownerDocument || document) ) {
 					eventPath.push( tmp.defaultView || tmp.parentWindow || window );
 				}
 			}
-	
+
 			// Fire handlers on the event path
 			i = 0;
 			while ( (cur = eventPath[i++]) && !event.isPropagationStopped() ) {
-	
+
 				event.type = i > 1 ?
 					bubbleType :
 					special.bindType || type;
-	
+
 				// jQuery handler
 				handle = ( data_priv.get( cur, "events" ) || {} )[ event.type ] && data_priv.get( cur, "handle" );
 				if ( handle ) {
 					handle.apply( cur, data );
 				}
-	
+
 				// Native handler
 				handle = ontype && cur[ ontype ];
 				if ( handle && jQuery.acceptData( cur ) && handle.apply && handle.apply( cur, data ) === false ) {
@@ -6143,80 +6144,80 @@
 				}
 			}
 			event.type = type;
-	
+
 			// If nobody prevented the default action, do it now
 			if ( !onlyHandlers && !event.isDefaultPrevented() ) {
-	
+
 				if ( (!special._default || special._default.apply( eventPath.pop(), data ) === false) &&
 					jQuery.acceptData( elem ) ) {
-	
+
 					// Call a native DOM method on the target with the same name name as the event.
 					// Don't do default actions on window, that's where global variables be (#6170)
 					if ( ontype && jQuery.isFunction( elem[ type ] ) && !jQuery.isWindow( elem ) ) {
-	
+
 						// Don't re-trigger an onFOO event when we call its FOO() method
 						tmp = elem[ ontype ];
-	
+
 						if ( tmp ) {
 							elem[ ontype ] = null;
 						}
-	
+
 						// Prevent re-triggering of the same event, since we already bubbled it above
 						jQuery.event.triggered = type;
 						elem[ type ]();
 						jQuery.event.triggered = undefined;
-	
+
 						if ( tmp ) {
 							elem[ ontype ] = tmp;
 						}
 					}
 				}
 			}
-	
+
 			return event.result;
 		},
-	
+
 		dispatch: function( event ) {
-	
+
 			// Make a writable jQuery.Event from the native event object
 			event = jQuery.event.fix( event );
-	
+
 			var i, j, ret, matched, handleObj,
 				handlerQueue = [],
 				args = core_slice.call( arguments ),
 				handlers = ( data_priv.get( this, "events" ) || {} )[ event.type ] || [],
 				special = jQuery.event.special[ event.type ] || {};
-	
+
 			// Use the fix-ed jQuery.Event rather than the (read-only) native event
 			args[0] = event;
 			event.delegateTarget = this;
-	
+
 			// Call the preDispatch hook for the mapped type, and let it bail if desired
 			if ( special.preDispatch && special.preDispatch.call( this, event ) === false ) {
 				return;
 			}
-	
+
 			// Determine handlers
 			handlerQueue = jQuery.event.handlers.call( this, event, handlers );
-	
+
 			// Run delegates first; they may want to stop propagation beneath us
 			i = 0;
 			while ( (matched = handlerQueue[ i++ ]) && !event.isPropagationStopped() ) {
 				event.currentTarget = matched.elem;
-	
+
 				j = 0;
 				while ( (handleObj = matched.handlers[ j++ ]) && !event.isImmediatePropagationStopped() ) {
-	
+
 					// Triggered event must either 1) have no namespace, or
 					// 2) have namespace(s) a subset or equal to those in the bound event (both can have no namespace).
 					if ( !event.namespace_re || event.namespace_re.test( handleObj.namespace ) ) {
-	
+
 						event.handleObj = handleObj;
 						event.data = handleObj.data;
-	
+
 						ret = ( (jQuery.event.special[ handleObj.origType ] || {}).handle || handleObj.handler )
 								.apply( matched.elem, args );
-	
+
 						if ( ret !== undefined ) {
 							if ( (event.result = ret) === false ) {
 								event.preventDefault();
@@ -6226,37 +6227,37 @@
 					}
 				}
 			}
-	
+
 			// Call the postDispatch hook for the mapped type
 			if ( special.postDispatch ) {
 				special.postDispatch.call( this, event );
 			}
-	
+
 			return event.result;
 		},
-	
+
 		handlers: function( event, handlers ) {
 			var i, matches, sel, handleObj,
 				handlerQueue = [],
 				delegateCount = handlers.delegateCount,
 				cur = event.target;
-	
+
 			// Find delegate handlers
 			// Black-hole SVG <use> instance trees (#13180)
 			// Avoid non-left-click bubbling in Firefox (#3861)
 			if ( delegateCount && cur.nodeType && (!event.button || event.type !== "click") ) {
-	
+
 				for ( ; cur !== this; cur = cur.parentNode || this ) {
-	
+
 					// Don't process clicks on disabled elements (#6911, #8165, #11382, #11764)
 					if ( cur.disabled !== true || event.type !== "click" ) {
 						matches = [];
 						for ( i = 0; i < delegateCount; i++ ) {
 							handleObj = handlers[ i ];
-	
+
 							// Don't conflict with Object.prototype properties (#13203)
 							sel = handleObj.selector + " ";
-	
+
 							if ( matches[ sel ] === undefined ) {
 								matches[ sel ] = handleObj.needsContext ?
 									jQuery( sel, this ).index( cur ) >= 0 :
@@ -6272,70 +6273,70 @@
 					}
 				}
 			}
-	
+
 			// Add the remaining (directly-bound) handlers
 			if ( delegateCount < handlers.length ) {
 				handlerQueue.push({ elem: this, handlers: handlers.slice( delegateCount ) });
 			}
-	
+
 			return handlerQueue;
 		},
-	
+
 		// Includes some event props shared by KeyEvent and MouseEvent
 		props: "altKey bubbles cancelable ctrlKey currentTarget eventPhase metaKey relatedTarget shiftKey target timeStamp view which".split(" "),
-	
+
 		fixHooks: {},
-	
+
 		keyHooks: {
 			props: "char charCode key keyCode".split(" "),
 			filter: function( event, original ) {
-	
+
 				// Add which for key events
 				if ( event.which == null ) {
 					event.which = original.charCode != null ? original.charCode : original.keyCode;
 				}
-	
+
 				return event;
 			}
 		},
-	
+
 		mouseHooks: {
 			props: "button buttons clientX clientY offsetX offsetY pageX pageY screenX screenY toElement".split(" "),
 			filter: function( event, original ) {
 				var eventDoc, doc, body,
 					button = original.button;
-	
+
 				// Calculate pageX/Y if missing and clientX/Y available
 				if ( event.pageX == null && original.clientX != null ) {
 					eventDoc = event.target.ownerDocument || document;
 					doc = eventDoc.documentElement;
 					body = eventDoc.body;
-	
+
 					event.pageX = original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
 					event.pageY = original.clientY + ( doc && doc.scrollTop  || body && body.scrollTop  || 0 ) - ( doc && doc.clientTop  || body && body.clientTop  || 0 );
 				}
-	
+
 				// Add which for click: 1 === left; 2 === middle; 3 === right
 				// Note: button is not normalized, so don't use it
 				if ( !event.which && button !== undefined ) {
 					event.which = ( button & 1 ? 1 : ( button & 2 ? 3 : ( button & 4 ? 2 : 0 ) ) );
 				}
-	
+
 				return event;
 			}
 		},
-	
+
 		fix: function( event ) {
 			if ( event[ jQuery.expando ] ) {
 				return event;
 			}
-	
+
 			// Create a writable copy of the event object and normalize some properties
 			var i, prop, copy,
 				type = event.type,
 				originalEvent = event,
 				fixHook = this.fixHooks[ type ];
-	
+
 			if ( !fixHook ) {
 				this.fixHooks[ type ] = fixHook =
 					rmouseEvent.test( type ) ? this.mouseHooks :
@@ -6343,30 +6344,30 @@
 					{};
 			}
 			copy = fixHook.props ? this.props.concat( fixHook.props ) : this.props;
-	
+
 			event = new jQuery.Event( originalEvent );
-	
+
 			i = copy.length;
 			while ( i-- ) {
 				prop = copy[ i ];
 				event[ prop ] = originalEvent[ prop ];
 			}
-	
+
 			// Support: Cordova 2.5 (WebKit) (#13255)
 			// All events should have a target; Cordova deviceready doesn't
 			if ( !event.target ) {
 				event.target = document;
 			}
-	
+
 			// Support: Safari 6.0+, Chrome < 28
 			// Target should not be a text node (#504, #13143)
 			if ( event.target.nodeType === 3 ) {
 				event.target = event.target.parentNode;
 			}
-	
+
 			return fixHook.filter? fixHook.filter( event, originalEvent ) : event;
 		},
-	
+
 		special: {
 			load: {
 				// Prevent triggered image.load events from bubbling to window.load
@@ -6399,16 +6400,16 @@
 						return false;
 					}
 				},
-	
+
 				// For cross-browser consistency, don't fire native .click() on links
 				_default: function( event ) {
 					return jQuery.nodeName( event.target, "a" );
 				}
 			},
-	
+
 			beforeunload: {
 				postDispatch: function( event ) {
-	
+
 					// Support: Firefox 20+
 					// Firefox doesn't alert if the returnValue field is not set.
 					if ( event.result !== undefined ) {
@@ -6417,7 +6418,7 @@
 				}
 			}
 		},
-	
+
 		simulate: function( type, elem, event, bubble ) {
 			// Piggyback on a donor event to simulate a different one.
 			// Fake originalEvent to avoid donor's stopPropagation, but if the
@@ -6441,67 +6442,67 @@
 			}
 		}
 	};
-	
+
 	jQuery.removeEvent = function( elem, type, handle ) {
 		if ( elem.removeEventListener ) {
 			elem.removeEventListener( type, handle, false );
 		}
 	};
-	
+
 	jQuery.Event = function( src, props ) {
 		// Allow instantiation without the 'new' keyword
 		if ( !(this instanceof jQuery.Event) ) {
 			return new jQuery.Event( src, props );
 		}
-	
+
 		// Event object
 		if ( src && src.type ) {
 			this.originalEvent = src;
 			this.type = src.type;
-	
+
 			// Events bubbling up the document may have been marked as prevented
 			// by a handler lower down the tree; reflect the correct value.
 			this.isDefaultPrevented = ( src.defaultPrevented ||
 				src.getPreventDefault && src.getPreventDefault() ) ? returnTrue : returnFalse;
-	
+
 		// Event type
 		} else {
 			this.type = src;
 		}
-	
+
 		// Put explicitly provided properties onto the event object
 		if ( props ) {
 			jQuery.extend( this, props );
 		}
-	
+
 		// Create a timestamp if incoming event doesn't have one
 		this.timeStamp = src && src.timeStamp || jQuery.now();
-	
+
 		// Mark it as fixed
 		this[ jQuery.expando ] = true;
 	};
-	
+
 	// jQuery.Event is based on DOM3 Events as specified by the ECMAScript Language Binding
 	// http://www.w3.org/TR/2003/WD-DOM-Level-3-Events-20030331/ecma-script-binding.html
 	jQuery.Event.prototype = {
 		isDefaultPrevented: returnFalse,
 		isPropagationStopped: returnFalse,
 		isImmediatePropagationStopped: returnFalse,
-	
+
 		preventDefault: function() {
 			var e = this.originalEvent;
-	
+
 			this.isDefaultPrevented = returnTrue;
-	
+
 			if ( e && e.preventDefault ) {
 				e.preventDefault();
 			}
 		},
 		stopPropagation: function() {
 			var e = this.originalEvent;
-	
+
 			this.isPropagationStopped = returnTrue;
-	
+
 			if ( e && e.stopPropagation ) {
 				e.stopPropagation();
 			}
@@ -6511,7 +6512,7 @@
 			this.stopPropagation();
 		}
 	};
-	
+
 	// Create mouseenter/leave events using mouseover/out and event-time checks
 	// Support: Chrome 15+
 	jQuery.each({
@@ -6521,13 +6522,13 @@
 		jQuery.event.special[ orig ] = {
 			delegateType: fix,
 			bindType: fix,
-	
+
 			handle: function( event ) {
 				var ret,
 					target = this,
 					related = event.relatedTarget,
 					handleObj = event.handleObj;
-	
+
 				// For mousenter/leave call the handler if related is outside the target.
 				// NB: No relatedTarget if the mouse left/entered the browser window
 				if ( !related || (related !== target && !jQuery.contains( target, related )) ) {
@@ -6539,18 +6540,18 @@
 			}
 		};
 	});
-	
+
 	// Create "bubbling" focus and blur events
 	// Support: Firefox, Chrome, Safari
 	if ( !jQuery.support.focusinBubbles ) {
 		jQuery.each({ focus: "focusin", blur: "focusout" }, function( orig, fix ) {
-	
+
 			// Attach a single capturing handler while someone wants focusin/focusout
 			var attaches = 0,
 				handler = function( event ) {
 					jQuery.event.simulate( fix, event.target, jQuery.event.fix( event ), true );
 				};
-	
+
 			jQuery.event.special[ fix ] = {
 				setup: function() {
 					if ( attaches++ === 0 ) {
@@ -6565,12 +6566,12 @@
 			};
 		});
 	}
-	
+
 	jQuery.fn.extend({
-	
+
 		on: function( types, selector, data, fn, /*INTERNAL*/ one ) {
 			var origFn, type;
-	
+
 			// Types can be a map of types/handlers
 			if ( typeof types === "object" ) {
 				// ( types-Object, selector, data )
@@ -6584,7 +6585,7 @@
 				}
 				return this;
 			}
-	
+
 			if ( data == null && fn == null ) {
 				// ( types, fn )
 				fn = selector;
@@ -6606,7 +6607,7 @@
 			} else if ( !fn ) {
 				return this;
 			}
-	
+
 			if ( one === 1 ) {
 				origFn = fn;
 				fn = function( event ) {
@@ -6655,7 +6656,7 @@
 				jQuery.event.remove( this, types, fn, selector );
 			});
 		},
-	
+
 		trigger: function( type, data ) {
 			return this.each(function() {
 				jQuery.event.trigger( type, data, this );
@@ -6678,14 +6679,14 @@
 			next: true,
 			prev: true
 		};
-	
+
 	jQuery.fn.extend({
 		find: function( selector ) {
 			var i,
 				ret = [],
 				self = this,
 				len = self.length;
-	
+
 			if ( typeof selector !== "string" ) {
 				return this.pushStack( jQuery( selector ).filter(function() {
 					for ( i = 0; i < len; i++ ) {
@@ -6695,21 +6696,21 @@
 					}
 				}) );
 			}
-	
+
 			for ( i = 0; i < len; i++ ) {
 				jQuery.find( selector, self[ i ], ret );
 			}
-	
+
 			// Needed because $( selector, context ) becomes $( context ).find( selector )
 			ret = this.pushStack( len > 1 ? jQuery.unique( ret ) : ret );
 			ret.selector = this.selector ? this.selector + " " + selector : selector;
 			return ret;
 		},
-	
+
 		has: function( target ) {
 			var targets = jQuery( target, this ),
 				l = targets.length;
-	
+
 			return this.filter(function() {
 				var i = 0;
 				for ( ; i < l; i++ ) {
@@ -6719,19 +6720,19 @@
 				}
 			});
 		},
-	
+
 		not: function( selector ) {
 			return this.pushStack( winnow(this, selector || [], true) );
 		},
-	
+
 		filter: function( selector ) {
 			return this.pushStack( winnow(this, selector || [], false) );
 		},
-	
+
 		is: function( selector ) {
 			return !!winnow(
 				this,
-	
+
 				// If this is a positional/relative selector, check membership in the returned set
 				// so $("p:first").is("p:last") won't return true for a doc with two "p".
 				typeof selector === "string" && rneedsContext.test( selector ) ?
@@ -6740,7 +6741,7 @@
 				false
 			).length;
 		},
-	
+
 		closest: function( selectors, context ) {
 			var cur,
 				i = 0,
@@ -6749,70 +6750,70 @@
 				pos = ( rneedsContext.test( selectors ) || typeof selectors !== "string" ) ?
 					jQuery( selectors, context || this.context ) :
 					0;
-	
+
 			for ( ; i < l; i++ ) {
 				for ( cur = this[i]; cur && cur !== context; cur = cur.parentNode ) {
 					// Always skip document fragments
 					if ( cur.nodeType < 11 && (pos ?
 						pos.index(cur) > -1 :
-	
+
 						// Don't pass non-elements to Sizzle
 						cur.nodeType === 1 &&
 							jQuery.find.matchesSelector(cur, selectors)) ) {
-	
+
 						cur = matched.push( cur );
 						break;
 					}
 				}
 			}
-	
+
 			return this.pushStack( matched.length > 1 ? jQuery.unique( matched ) : matched );
 		},
-	
+
 		// Determine the position of an element within
 		// the matched set of elements
 		index: function( elem ) {
-	
+
 			// No argument, return index in parent
 			if ( !elem ) {
 				return ( this[ 0 ] && this[ 0 ].parentNode ) ? this.first().prevAll().length : -1;
 			}
-	
+
 			// index in selector
 			if ( typeof elem === "string" ) {
 				return core_indexOf.call( jQuery( elem ), this[ 0 ] );
 			}
-	
+
 			// Locate the position of the desired element
 			return core_indexOf.call( this,
-	
+
 				// If it receives a jQuery object, the first element is used
 				elem.jquery ? elem[ 0 ] : elem
 			);
 		},
-	
+
 		add: function( selector, context ) {
 			var set = typeof selector === "string" ?
 					jQuery( selector, context ) :
 					jQuery.makeArray( selector && selector.nodeType ? [ selector ] : selector ),
 				all = jQuery.merge( this.get(), set );
-	
+
 			return this.pushStack( jQuery.unique(all) );
 		},
-	
+
 		addBack: function( selector ) {
 			return this.add( selector == null ?
 				this.prevObject : this.prevObject.filter(selector)
 			);
 		}
 	});
-	
+
 	function sibling( cur, dir ) {
 		while ( (cur = cur[dir]) && cur.nodeType !== 1 ) {}
-	
+
 		return cur;
 	}
-	
+
 	jQuery.each({
 		parent: function( elem ) {
 			var parent = elem.parentNode;
@@ -6854,50 +6855,50 @@
 	}, function( name, fn ) {
 		jQuery.fn[ name ] = function( until, selector ) {
 			var matched = jQuery.map( this, fn, until );
-	
+
 			if ( name.slice( -5 ) !== "Until" ) {
 				selector = until;
 			}
-	
+
 			if ( selector && typeof selector === "string" ) {
 				matched = jQuery.filter( selector, matched );
 			}
-	
+
 			if ( this.length > 1 ) {
 				// Remove duplicates
 				if ( !guaranteedUnique[ name ] ) {
 					jQuery.unique( matched );
 				}
-	
+
 				// Reverse order for parents* and prev-derivatives
 				if ( rparentsprev.test( name ) ) {
 					matched.reverse();
 				}
 			}
-	
+
 			return this.pushStack( matched );
 		};
 	});
-	
+
 	jQuery.extend({
 		filter: function( expr, elems, not ) {
 			var elem = elems[ 0 ];
-	
+
 			if ( not ) {
 				expr = ":not(" + expr + ")";
 			}
-	
+
 			return elems.length === 1 && elem.nodeType === 1 ?
 				jQuery.find.matchesSelector( elem, expr ) ? [ elem ] : [] :
 				jQuery.find.matches( expr, jQuery.grep( elems, function( elem ) {
 					return elem.nodeType === 1;
 				}));
 		},
-	
+
 		dir: function( elem, dir, until ) {
 			var matched = [],
 				truncate = until !== undefined;
-	
+
 			while ( (elem = elem[ dir ]) && elem.nodeType !== 9 ) {
 				if ( elem.nodeType === 1 ) {
 					if ( truncate && jQuery( elem ).is( until ) ) {
@@ -6908,20 +6909,20 @@
 			}
 			return matched;
 		},
-	
+
 		sibling: function( n, elem ) {
 			var matched = [];
-	
+
 			for ( ; n; n = n.nextSibling ) {
 				if ( n.nodeType === 1 && n !== elem ) {
 					matched.push( n );
 				}
 			}
-	
+
 			return matched;
 		}
 	});
-	
+
 	// Implement the identical functionality for filter and not
 	function winnow( elements, qualifier, not ) {
 		if ( jQuery.isFunction( qualifier ) ) {
@@ -6929,24 +6930,24 @@
 				/* jshint -W018 */
 				return !!qualifier.call( elem, i, elem ) !== not;
 			});
-	
+
 		}
-	
+
 		if ( qualifier.nodeType ) {
 			return jQuery.grep( elements, function( elem ) {
 				return ( elem === qualifier ) !== not;
 			});
-	
+
 		}
-	
+
 		if ( typeof qualifier === "string" ) {
 			if ( isSimple.test( qualifier ) ) {
 				return jQuery.filter( qualifier, elements, not );
 			}
-	
+
 			qualifier = jQuery.filter( qualifier, elements );
 		}
-	
+
 		return jQuery.grep( elements, function( elem ) {
 			return ( core_indexOf.call( qualifier, elem ) >= 0 ) !== not;
 		});
@@ -6961,27 +6962,27 @@
 		rscriptType = /^$|\/(?:java|ecma)script/i,
 		rscriptTypeMasked = /^true\/(.*)/,
 		rcleanScript = /^\s*<!(?:\[CDATA\[|--)|(?:\]\]|--)>\s*$/g,
-	
+
 		// We have to close these tags to support XHTML (#13200)
 		wrapMap = {
-	
+
 			// Support: IE 9
 			option: [ 1, "<select multiple='multiple'>", "</select>" ],
-	
+
 			thead: [ 1, "<table>", "</table>" ],
 			col: [ 2, "<table><colgroup>", "</colgroup></table>" ],
 			tr: [ 2, "<table><tbody>", "</tbody></table>" ],
 			td: [ 3, "<table><tbody><tr>", "</tr></tbody></table>" ],
-	
+
 			_default: [ 0, "", "" ]
 		};
-	
+
 	// Support: IE 9
 	wrapMap.optgroup = wrapMap.option;
-	
+
 	wrapMap.tbody = wrapMap.tfoot = wrapMap.colgroup = wrapMap.caption = wrapMap.thead;
 	wrapMap.th = wrapMap.td;
-	
+
 	jQuery.fn.extend({
 		text: function( value ) {
 			return jQuery.access( this, function( value ) {
@@ -6990,7 +6991,7 @@
 					this.empty().append( ( this[ 0 ] && this[ 0 ].ownerDocument || document ).createTextNode( value ) );
 			}, null, value, arguments.length );
 		},
-	
+
 		append: function() {
 			return this.domManip( arguments, function( elem ) {
 				if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
@@ -6999,7 +7000,7 @@
 				}
 			});
 		},
-	
+
 		prepend: function() {
 			return this.domManip( arguments, function( elem ) {
 				if ( this.nodeType === 1 || this.nodeType === 11 || this.nodeType === 9 ) {
@@ -7008,7 +7009,7 @@
 				}
 			});
 		},
-	
+
 		before: function() {
 			return this.domManip( arguments, function( elem ) {
 				if ( this.parentNode ) {
@@ -7016,7 +7017,7 @@
 				}
 			});
 		},
-	
+
 		after: function() {
 			return this.domManip( arguments, function( elem ) {
 				if ( this.parentNode ) {
@@ -7024,18 +7025,18 @@
 				}
 			});
 		},
-	
+
 		// keepData is for internal use only--do not document
 		remove: function( selector, keepData ) {
 			var elem,
 				elems = selector ? jQuery.filter( selector, this ) : this,
 				i = 0;
-	
+
 			for ( ; (elem = elems[i]) != null; i++ ) {
 				if ( !keepData && elem.nodeType === 1 ) {
 					jQuery.cleanData( getAll( elem ) );
 				}
-	
+
 				if ( elem.parentNode ) {
 					if ( keepData && jQuery.contains( elem.ownerDocument, elem ) ) {
 						setGlobalEval( getAll( elem, "script" ) );
@@ -7043,76 +7044,76 @@
 					elem.parentNode.removeChild( elem );
 				}
 			}
-	
+
 			return this;
 		},
-	
+
 		empty: function() {
 			var elem,
 				i = 0;
-	
+
 			for ( ; (elem = this[i]) != null; i++ ) {
 				if ( elem.nodeType === 1 ) {
-	
+
 					// Prevent memory leaks
 					jQuery.cleanData( getAll( elem, false ) );
-	
+
 					// Remove any remaining nodes
 					elem.textContent = "";
 				}
 			}
-	
+
 			return this;
 		},
-	
+
 		clone: function( dataAndEvents, deepDataAndEvents ) {
 			dataAndEvents = dataAndEvents == null ? false : dataAndEvents;
 			deepDataAndEvents = deepDataAndEvents == null ? dataAndEvents : deepDataAndEvents;
-	
+
 			return this.map( function () {
 				return jQuery.clone( this, dataAndEvents, deepDataAndEvents );
 			});
 		},
-	
+
 		html: function( value ) {
 			return jQuery.access( this, function( value ) {
 				var elem = this[ 0 ] || {},
 					i = 0,
 					l = this.length;
-	
+
 				if ( value === undefined && elem.nodeType === 1 ) {
 					return elem.innerHTML;
 				}
-	
+
 				// See if we can take a shortcut and just use innerHTML
 				if ( typeof value === "string" && !rnoInnerhtml.test( value ) &&
 					!wrapMap[ ( rtagName.exec( value ) || [ "", "" ] )[ 1 ].toLowerCase() ] ) {
-	
+
 					value = value.replace( rxhtmlTag, "<$1></$2>" );
-	
+
 					try {
 						for ( ; i < l; i++ ) {
 							elem = this[ i ] || {};
-	
+
 							// Remove element nodes and prevent memory leaks
 							if ( elem.nodeType === 1 ) {
 								jQuery.cleanData( getAll( elem, false ) );
 								elem.innerHTML = value;
 							}
 						}
-	
+
 						elem = 0;
-	
+
 					// If using innerHTML throws an exception, use the fallback method
 					} catch( e ) {}
 				}
-	
+
 				if ( elem ) {
 					this.empty().append( value );
 				}
 			}, null, value, arguments.length );
 		},
-	
+
 		replaceWith: function() {
 			var
 				// Snapshot the DOM in case .domManip sweeps something relevant into its fragment
@@ -7120,12 +7121,12 @@
 					return [ elem.nextSibling, elem.parentNode ];
 				}),
 				i = 0;
-	
+
 			// Make the changes, replacing each context element with the new content
 			this.domManip( arguments, function( elem ) {
 				var next = args[ i++ ],
 					parent = args[ i++ ];
-	
+
 				if ( parent ) {
 					// Don't use the snapshot next if it has moved (#13810)
 					if ( next && next.parentNode !== parent ) {
@@ -7136,20 +7137,20 @@
 				}
 			// Allow new content to include elements from the context set
 			}, true );
-	
+
 			// Force removal if there was no new content (e.g., from empty arguments)
 			return i ? this : this.remove();
 		},
-	
+
 		detach: function( selector ) {
 			return this.remove( selector, true );
 		},
-	
+
 		domManip: function( args, callback, allowIntersection ) {
-	
+
 			// Flatten any nested arrays
 			args = core_concat.apply( [], args );
-	
+
 			var fragment, first, scripts, hasScripts, node, doc,
 				i = 0,
 				l = this.length,
@@ -7157,7 +7158,7 @@
 				iNoClone = l - 1,
 				value = args[ 0 ],
 				isFunction = jQuery.isFunction( value );
-	
+
 			// We can't cloneNode fragments that contain checked, in WebKit
 			if ( isFunction || !( l <= 1 || typeof value !== "string" || jQuery.support.checkClone || !rchecked.test( value ) ) ) {
 				return this.each(function( index ) {
@@ -7168,27 +7169,27 @@
 					self.domManip( args, callback, allowIntersection );
 				});
 			}
-	
+
 			if ( l ) {
 				fragment = jQuery.buildFragment( args, this[ 0 ].ownerDocument, false, !allowIntersection && this );
 				first = fragment.firstChild;
-	
+
 				if ( fragment.childNodes.length === 1 ) {
 					fragment = first;
 				}
-	
+
 				if ( first ) {
 					scripts = jQuery.map( getAll( fragment, "script" ), disableScript );
 					hasScripts = scripts.length;
-	
+
 					// Use the original fragment for the last item instead of the first because it can end up
 					// being emptied incorrectly in certain situations (#8070).
 					for ( ; i < l; i++ ) {
 						node = fragment;
-	
+
 						if ( i !== iNoClone ) {
 							node = jQuery.clone( node, true, true );
-	
+
 							// Keep references to cloned scripts for later restoration
 							if ( hasScripts ) {
 								// Support: QtWebKit
@@ -7196,22 +7197,22 @@
 								jQuery.merge( scripts, getAll( node, "script" ) );
 							}
 						}
-	
+
 						callback.call( this[ i ], node, i );
 					}
-	
+
 					if ( hasScripts ) {
 						doc = scripts[ scripts.length - 1 ].ownerDocument;
-	
+
 						// Reenable scripts
 						jQuery.map( scripts, restoreScript );
-	
+
 						// Evaluate executable scripts on first document insertion
 						for ( i = 0; i < hasScripts; i++ ) {
 							node = scripts[ i ];
 							if ( rscriptType.test( node.type || "" ) &&
 								!data_priv.access( node, "globalEval" ) && jQuery.contains( doc, node ) ) {
-	
+
 								if ( node.src ) {
 									// Hope ajax is available...
 									jQuery._evalUrl( node.src );
@@ -7223,11 +7224,11 @@
 					}
 				}
 			}
-	
+
 			return this;
 		}
 	});
-	
+
 	jQuery.each({
 		appendTo: "append",
 		prependTo: "prepend",
@@ -7241,45 +7242,45 @@
 				insert = jQuery( selector ),
 				last = insert.length - 1,
 				i = 0;
-	
+
 			for ( ; i <= last; i++ ) {
 				elems = i === last ? this : this.clone( true );
 				jQuery( insert[ i ] )[ original ]( elems );
-	
+
 				// Support: QtWebKit
 				// .get() because core_push.apply(_, arraylike) throws
 				core_push.apply( ret, elems.get() );
 			}
-	
+
 			return this.pushStack( ret );
 		};
 	});
-	
+
 	jQuery.extend({
 		clone: function( elem, dataAndEvents, deepDataAndEvents ) {
 			var i, l, srcElements, destElements,
 				clone = elem.cloneNode( true ),
 				inPage = jQuery.contains( elem.ownerDocument, elem );
-	
+
 			// Support: IE >= 9
 			// Fix Cloning issues
 			if ( !jQuery.support.noCloneChecked && ( elem.nodeType === 1 || elem.nodeType === 11 ) && !jQuery.isXMLDoc( elem ) ) {
-	
+
 				// We eschew Sizzle here for performance reasons: http://jsperf.com/getall-vs-sizzle/2
 				destElements = getAll( clone );
 				srcElements = getAll( elem );
-	
+
 				for ( i = 0, l = srcElements.length; i < l; i++ ) {
 					fixInput( srcElements[ i ], destElements[ i ] );
 				}
 			}
-	
+
 			// Copy the events from the original to the clone
 			if ( dataAndEvents ) {
 				if ( deepDataAndEvents ) {
 					srcElements = srcElements || getAll( elem );
 					destElements = destElements || getAll( clone );
-	
+
 					for ( i = 0, l = srcElements.length; i < l; i++ ) {
 						cloneCopyEvent( srcElements[ i ], destElements[ i ] );
 					}
@@ -7287,90 +7288,90 @@
 					cloneCopyEvent( elem, clone );
 				}
 			}
-	
+
 			// Preserve script evaluation history
 			destElements = getAll( clone, "script" );
 			if ( destElements.length > 0 ) {
 				setGlobalEval( destElements, !inPage && getAll( elem, "script" ) );
 			}
-	
+
 			// Return the cloned set
 			return clone;
 		},
-	
+
 		buildFragment: function( elems, context, scripts, selection ) {
 			var elem, tmp, tag, wrap, contains, j,
 				i = 0,
 				l = elems.length,
 				fragment = context.createDocumentFragment(),
 				nodes = [];
-	
+
 			for ( ; i < l; i++ ) {
 				elem = elems[ i ];
-	
+
 				if ( elem || elem === 0 ) {
-	
+
 					// Add nodes directly
 					if ( jQuery.type( elem ) === "object" ) {
 						// Support: QtWebKit
 						// jQuery.merge because core_push.apply(_, arraylike) throws
 						jQuery.merge( nodes, elem.nodeType ? [ elem ] : elem );
-	
+
 					// Convert non-html into a text node
 					} else if ( !rhtml.test( elem ) ) {
 						nodes.push( context.createTextNode( elem ) );
-	
+
 					// Convert html into DOM nodes
 					} else {
 						tmp = tmp || fragment.appendChild( context.createElement("div") );
-	
+
 						// Deserialize a standard representation
 						tag = ( rtagName.exec( elem ) || ["", ""] )[ 1 ].toLowerCase();
 						wrap = wrapMap[ tag ] || wrapMap._default;
 						tmp.innerHTML = wrap[ 1 ] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[ 2 ];
-	
+
 						// Descend through wrappers to the right content
 						j = wrap[ 0 ];
 						while ( j-- ) {
 							tmp = tmp.lastChild;
 						}
-	
+
 						// Support: QtWebKit
 						// jQuery.merge because core_push.apply(_, arraylike) throws
 						jQuery.merge( nodes, tmp.childNodes );
-	
+
 						// Remember the top-level container
 						tmp = fragment.firstChild;
-	
+
 						// Fixes #12346
 						// Support: Webkit, IE
 						tmp.textContent = "";
 					}
 				}
 			}
-	
+
 			// Remove wrapper from fragment
 			fragment.textContent = "";
-	
+
 			i = 0;
 			while ( (elem = nodes[ i++ ]) ) {
-	
+
 				// #4087 - If origin and destination elements are the same, and this is
 				// that element, do not do anything
 				if ( selection && jQuery.inArray( elem, selection ) !== -1 ) {
 					continue;
 				}
-	
+
 				contains = jQuery.contains( elem.ownerDocument, elem );
-	
+
 				// Append to fragment
 				tmp = getAll( fragment.appendChild( elem ), "script" );
-	
+
 				// Preserve script evaluation history
 				if ( contains ) {
 					setGlobalEval( tmp );
 				}
-	
+
 				// Capture executables
 				if ( scripts ) {
 					j = 0;
@@ -7381,26 +7382,26 @@
 					}
 				}
 			}
-	
+
 			return fragment;
 		},
-	
+
 		cleanData: function( elems ) {
 			var data, elem, events, type, key, j,
 				special = jQuery.event.special,
 				i = 0;
-	
+
 			for ( ; (elem = elems[ i ]) !== undefined; i++ ) {
 				if ( Data.accepts( elem ) ) {
 					key = elem[ data_priv.expando ];
-	
+
 					if ( key && (data = data_priv.cache[ key ]) ) {
 						events = Object.keys( data.events || {} );
 						if ( events.length ) {
 							for ( j = 0; (type = events[j]) !== undefined; j++ ) {
 								if ( special[ type ] ) {
 									jQuery.event.remove( elem, type );
-	
+
 								// This is a shortcut to avoid jQuery.event.remove's overhead
 								} else {
 									jQuery.removeEvent( elem, type, data.handle );
@@ -7417,7 +7418,7 @@
 				delete data_user.cache[ elem[ data_user.expando ] ];
 			}
 		},
-	
+
 		_evalUrl: function( url ) {
 			return jQuery.ajax({
 				url: url,
@@ -7429,18 +7430,18 @@
 			});
 		}
 	});
-	
+
 	// Support: 1.x compatibility
 	// Manipulating tables requires a tbody
 	function manipulationTarget( elem, content ) {
 		return jQuery.nodeName( elem, "table" ) &&
 			jQuery.nodeName( content.nodeType === 1 ? content : content.firstChild, "tr" ) ?
-	
+
 			elem.getElementsByTagName("tbody")[0] ||
 				elem.appendChild( elem.ownerDocument.createElement("tbody") ) :
 			elem;
 	}
-	
+
 	// Replace/restore the type attribute of script elements for safe DOM manipulation
 	function disableScript( elem ) {
 		elem.type = (elem.getAttribute("type") !== null) + "/" + elem.type;
@@ -7448,45 +7449,45 @@
 	}
 	function restoreScript( elem ) {
 		var match = rscriptTypeMasked.exec( elem.type );
-	
+
 		if ( match ) {
 			elem.type = match[ 1 ];
 		} else {
 			elem.removeAttribute("type");
 		}
-	
+
 		return elem;
 	}
-	
+
 	// Mark scripts as having already been evaluated
 	function setGlobalEval( elems, refElements ) {
 		var l = elems.length,
 			i = 0;
-	
+
 		for ( ; i < l; i++ ) {
 			data_priv.set(
 				elems[ i ], "globalEval", !refElements || data_priv.get( refElements[ i ], "globalEval" )
 			);
 		}
 	}
-	
+
 	function cloneCopyEvent( src, dest ) {
 		var i, l, type, pdataOld, pdataCur, udataOld, udataCur, events;
-	
+
 		if ( dest.nodeType !== 1 ) {
 			return;
 		}
-	
+
 		// 1. Copy private data: events, handlers, etc.
 		if ( data_priv.hasData( src ) ) {
 			pdataOld = data_priv.access( src );
 			pdataCur = data_priv.set( dest, pdataOld );
 			events = pdataOld.events;
-	
+
 			if ( events ) {
 				delete pdataCur.handle;
 				pdataCur.events = {};
-	
+
 				for ( type in events ) {
 					for ( i = 0, l = events[ type ].length; i < l; i++ ) {
 						jQuery.event.add( dest, type, events[ type ][ i ] );
@@ -7494,35 +7495,35 @@
 				}
 			}
 		}
-	
+
 		// 2. Copy user data
 		if ( data_user.hasData( src ) ) {
 			udataOld = data_user.access( src );
 			udataCur = jQuery.extend( {}, udataOld );
-	
+
 			data_user.set( dest, udataCur );
 		}
 	}
-	
-	
+
+
 	function getAll( context, tag ) {
 		var ret = context.getElementsByTagName ? context.getElementsByTagName( tag || "*" ) :
 				context.querySelectorAll ? context.querySelectorAll( tag || "*" ) :
 				[];
-	
+
 		return tag === undefined || tag && jQuery.nodeName( context, tag ) ?
 			jQuery.merge( [ context ], ret ) :
 			ret;
 	}
-	
+
 	// Support: IE >= 9
 	function fixInput( src, dest ) {
 		var nodeName = dest.nodeName.toLowerCase();
-	
+
 		// Fails to persist the checked state of a cloned checkbox or radio button.
 		if ( nodeName === "input" && manipulation_rcheckableType.test( src.type ) ) {
 			dest.checked = src.checked;
-	
+
 		// Fails to return the selected option to the default selected state when cloning options
 		} else if ( nodeName === "input" || nodeName === "textarea" ) {
 			dest.defaultValue = src.defaultValue;
@@ -7531,64 +7532,64 @@
 	jQuery.fn.extend({
 		wrapAll: function( html ) {
 			var wrap;
-	
+
 			if ( jQuery.isFunction( html ) ) {
 				return this.each(function( i ) {
 					jQuery( this ).wrapAll( html.call(this, i) );
 				});
 			}
-	
+
 			if ( this[ 0 ] ) {
-	
+
 				// The elements to wrap the target around
 				wrap = jQuery( html, this[ 0 ].ownerDocument ).eq( 0 ).clone( true );
-	
+
 				if ( this[ 0 ].parentNode ) {
 					wrap.insertBefore( this[ 0 ] );
 				}
-	
+
 				wrap.map(function() {
 					var elem = this;
-	
+
 					while ( elem.firstElementChild ) {
 						elem = elem.firstElementChild;
 					}
-	
+
 					return elem;
 				}).append( this );
 			}
-	
+
 			return this;
 		},
-	
+
 		wrapInner: function( html ) {
 			if ( jQuery.isFunction( html ) ) {
 				return this.each(function( i ) {
 					jQuery( this ).wrapInner( html.call(this, i) );
 				});
 			}
-	
+
 			return this.each(function() {
 				var self = jQuery( this ),
 					contents = self.contents();
-	
+
 				if ( contents.length ) {
 					contents.wrapAll( html );
-	
+
 				} else {
 					self.append( html );
 				}
 			});
 		},
-	
+
 		wrap: function( html ) {
 			var isFunction = jQuery.isFunction( html );
-	
+
 			return this.each(function( i ) {
 				jQuery( this ).wrapAll( isFunction ? html.call(this, i) : html );
 			});
 		},
-	
+
 		unwrap: function() {
 			return this.parent().each(function() {
 				if ( !jQuery.nodeName( this, "body" ) ) {
@@ -7606,64 +7607,64 @@
 		rnumnonpx = new RegExp( "^(" + core_pnum + ")(?!px)[a-z%]+$", "i" ),
 		rrelNum = new RegExp( "^([+-])=(" + core_pnum + ")", "i" ),
 		elemdisplay = { BODY: "block" },
-	
+
 		cssShow = { position: "absolute", visibility: "hidden", display: "block" },
 		cssNormalTransform = {
 			letterSpacing: 0,
 			fontWeight: 400
 		},
-	
+
 		cssExpand = [ "Top", "Right", "Bottom", "Left" ],
 		cssPrefixes = [ "Webkit", "O", "Moz", "ms" ];
-	
+
 	// return a css property mapped to a potentially vendor prefixed property
 	function vendorPropName( style, name ) {
-	
+
 		// shortcut for names that are not vendor prefixed
 		if ( name in style ) {
 			return name;
 		}
-	
+
 		// check for vendor prefixed names
 		var capName = name.charAt(0).toUpperCase() + name.slice(1),
 			origName = name,
 			i = cssPrefixes.length;
-	
+
 		while ( i-- ) {
 			name = cssPrefixes[ i ] + capName;
 			if ( name in style ) {
 				return name;
 			}
 		}
-	
+
 		return origName;
 	}
-	
+
 	function isHidden( elem, el ) {
 		// isHidden might be called from jQuery#filter function;
 		// in that case, element will be second argument
 		elem = el || elem;
 		return jQuery.css( elem, "display" ) === "none" || !jQuery.contains( elem.ownerDocument, elem );
 	}
-	
+
 	// NOTE: we've included the "window" in window.getComputedStyle
 	// because jsdom on node.js will break without it.
 	function getStyles( elem ) {
 		return window.getComputedStyle( elem, null );
 	}
-	
+
 	function showHide( elements, show ) {
 		var display, elem, hidden,
 			values = [],
 			index = 0,
 			length = elements.length;
-	
+
 		for ( ; index < length; index++ ) {
 			elem = elements[ index ];
 			if ( !elem.style ) {
 				continue;
 			}
-	
+
 			values[ index ] = data_priv.get( elem, "olddisplay" );
 			display = elem.style.display;
 			if ( show ) {
@@ -7672,7 +7673,7 @@
 				if ( !values[ index ] && display === "none" ) {
 					elem.style.display = "";
 				}
-	
+
 				// Set elements which have been overridden with display: none
 				// in a stylesheet to whatever the default browser style is
 				// for such an element
@@ -7680,17 +7681,17 @@
 					values[ index ] = data_priv.access( elem, "olddisplay", css_defaultDisplay(elem.nodeName) );
 				}
 			} else {
-	
+
 				if ( !values[ index ] ) {
 					hidden = isHidden( elem );
-	
+
 					if ( display && display !== "none" || !hidden ) {
 						data_priv.set( elem, "olddisplay", hidden ? display : jQuery.css(elem, "display") );
 					}
 				}
 			}
 		}
-	
+
 		// Set the display of most of the elements in a second loop
 		// to avoid the constant reflow
 		for ( index = 0; index < length; index++ ) {
@@ -7702,28 +7703,28 @@
 				elem.style.display = show ? values[ index ] || "" : "none";
 			}
 		}
-	
+
 		return elements;
 	}
-	
+
 	jQuery.fn.extend({
 		css: function( name, value ) {
 			return jQuery.access( this, function( elem, name, value ) {
 				var styles, len,
 					map = {},
 					i = 0;
-	
+
 				if ( jQuery.isArray( name ) ) {
 					styles = getStyles( elem );
 					len = name.length;
-	
+
 					for ( ; i < len; i++ ) {
 						map[ name[ i ] ] = jQuery.css( elem, name[ i ], false, styles );
 					}
-	
+
 					return map;
 				}
-	
+
 				return value !== undefined ?
 					jQuery.style( elem, name, value ) :
 					jQuery.css( elem, name );
@@ -7739,7 +7740,7 @@
 			if ( typeof state === "boolean" ) {
 				return state ? this.show() : this.hide();
 			}
-	
+
 			return this.each(function() {
 				if ( isHidden( this ) ) {
 					jQuery( this ).show();
@@ -7749,7 +7750,7 @@
 			});
 		}
 	});
-	
+
 	jQuery.extend({
 		// Add in style property hooks for overriding the default
 		// behavior of getting and setting a style property
@@ -7764,7 +7765,7 @@
 				}
 			}
 		},
-	
+
 		// Don't automatically add "px" to these possibly-unitless properties
 		cssNumber: {
 			"columnCount": true,
@@ -7778,101 +7779,101 @@
 			"zIndex": true,
 			"zoom": true
 		},
-	
+
 		// Add in properties whose names you wish to fix before
 		// setting or getting the value
 		cssProps: {
 			// normalize float css property
 			"float": "cssFloat"
 		},
-	
+
 		// Get and set the style property on a DOM Node
 		style: function( elem, name, value, extra ) {
 			// Don't set styles on text and comment nodes
 			if ( !elem || elem.nodeType === 3 || elem.nodeType === 8 || !elem.style ) {
 				return;
 			}
-	
+
 			// Make sure that we're working with the right name
 			var ret, type, hooks,
 				origName = jQuery.camelCase( name ),
 				style = elem.style;
-	
+
 			name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( style, origName ) );
-	
+
 			// gets hook for the prefixed version
 			// followed by the unprefixed version
 			hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
-	
+
 			// Check if we're setting a value
 			if ( value !== undefined ) {
 				type = typeof value;
-	
+
 				// convert relative number strings (+= or -=) to relative numbers. #7345
 				if ( type === "string" && (ret = rrelNum.exec( value )) ) {
 					value = ( ret[1] + 1 ) * ret[2] + parseFloat( jQuery.css( elem, name ) );
 					// Fixes bug #9237
 					type = "number";
 				}
-	
+
 				// Make sure that NaN and null values aren't set. See: #7116
 				if ( value == null || type === "number" && isNaN( value ) ) {
 					return;
 				}
-	
+
 				// If a number was passed in, add 'px' to the (except for certain CSS properties)
 				if ( type === "number" && !jQuery.cssNumber[ origName ] ) {
 					value += "px";
 				}
-	
+
 				// Fixes #8908, it can be done more correctly by specifying setters in cssHooks,
 				// but it would mean to define eight (for every problematic property) identical functions
 				if ( !jQuery.support.clearCloneStyle && value === "" && name.indexOf("background") === 0 ) {
 					style[ name ] = "inherit";
 				}
-	
+
 				// If a hook was provided, use that value, otherwise just set the specified value
 				if ( !hooks || !("set" in hooks) || (value = hooks.set( elem, value, extra )) !== undefined ) {
 					style[ name ] = value;
 				}
-	
+
 			} else {
 				// If a hook was provided get the non-computed value from there
 				if ( hooks && "get" in hooks && (ret = hooks.get( elem, false, extra )) !== undefined ) {
 					return ret;
 				}
-	
+
 				// Otherwise just get the value from the style object
 				return style[ name ];
 			}
 		},
-	
+
 		css: function( elem, name, extra, styles ) {
 			var val, num, hooks,
 				origName = jQuery.camelCase( name );
-	
+
 			// Make sure that we're working with the right name
 			name = jQuery.cssProps[ origName ] || ( jQuery.cssProps[ origName ] = vendorPropName( elem.style, origName ) );
-	
+
 			// gets hook for the prefixed version
 			// followed by the unprefixed version
 			hooks = jQuery.cssHooks[ name ] || jQuery.cssHooks[ origName ];
-	
+
 			// If a hook was provided get the computed value from there
 			if ( hooks && "get" in hooks ) {
 				val = hooks.get( elem, true, extra );
 			}
-	
+
 			// Otherwise, if a way to get the computed value exists, use that
 			if ( val === undefined ) {
 				val = curCSS( elem, name, styles );
 			}
-	
+
 			//convert "normal" to computed value
 			if ( val === "normal" && name in cssNormalTransform ) {
 				val = cssNormalTransform[ name ];
 			}
-	
+
 			// Return, converting to number if forced or a qualifier was provided and val looks numeric
 			if ( extra === "" || extra ) {
 				num = parseFloat( val );
@@ -7881,48 +7882,48 @@
 			return val;
 		}
 	});
-	
+
 	curCSS = function( elem, name, _computed ) {
 		var width, minWidth, maxWidth,
 			computed = _computed || getStyles( elem ),
-	
+
 			// Support: IE9
 			// getPropertyValue is only needed for .css('filter') in IE9, see #12537
 			ret = computed ? computed.getPropertyValue( name ) || computed[ name ] : undefined,
 			style = elem.style;
-	
+
 		if ( computed ) {
-	
+
 			if ( ret === "" && !jQuery.contains( elem.ownerDocument, elem ) ) {
 				ret = jQuery.style( elem, name );
 			}
-	
+
 			// Support: Safari 5.1
 			// A tribute to the "awesome hack by Dean Edwards"
 			// Safari 5.1.7 (at least) returns percentage for a larger set of values, but width seems to be reliably pixels
 			// this is against the CSSOM draft spec: http://dev.w3.org/csswg/cssom/#resolved-values
 			if ( rnumnonpx.test( ret ) && rmargin.test( name ) ) {
-	
+
 				// Remember the original values
 				width = style.width;
 				minWidth = style.minWidth;
 				maxWidth = style.maxWidth;
-	
+
 				// Put in the new values to get a computed value out
 				style.minWidth = style.maxWidth = style.width = ret;
 				ret = computed.width;
-	
+
 				// Revert the changed values
 				style.width = width;
 				style.minWidth = minWidth;
 				style.maxWidth = maxWidth;
 			}
 		}
-	
+
 		return ret;
 	};
-	
-	
+
+
 	function setPositiveNumber( elem, value, subtract ) {
 		var matches = rnumsplit.exec( value );
 		return matches ?
@@ -7930,28 +7931,28 @@
 			Math.max( 0, matches[ 1 ] - ( subtract || 0 ) ) + ( matches[ 2 ] || "px" ) :
 			value;
 	}
-	
+
 	function augmentWidthOrHeight( elem, name, extra, isBorderBox, styles ) {
 		var i = extra === ( isBorderBox ? "border" : "content" ) ?
 			// If we already have the right measurement, avoid augmentation
 			4 :
 			// Otherwise initialize for horizontal or vertical properties
 			name === "width" ? 1 : 0,
-	
+
 			val = 0;
-	
+
 		for ( ; i < 4; i += 2 ) {
 			// both box models exclude margin, so add it if we want it
 			if ( extra === "margin" ) {
 				val += jQuery.css( elem, extra + cssExpand[ i ], true, styles );
 			}
-	
+
 			if ( isBorderBox ) {
 				// border-box includes padding, so remove it if we want content
 				if ( extra === "content" ) {
 					val -= jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
 				}
-	
+
 				// at this point, extra isn't border nor margin, so remove border
 				if ( extra !== "margin" ) {
 					val -= jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
@@ -7959,25 +7960,25 @@
 			} else {
 				// at this point, extra isn't content, so add padding
 				val += jQuery.css( elem, "padding" + cssExpand[ i ], true, styles );
-	
+
 				// at this point, extra isn't content nor padding, so add border
 				if ( extra !== "padding" ) {
 					val += jQuery.css( elem, "border" + cssExpand[ i ] + "Width", true, styles );
 				}
 			}
 		}
-	
+
 		return val;
 	}
-	
+
 	function getWidthOrHeight( elem, name, extra ) {
-	
+
 		// Start with offset property, which is equivalent to the border-box value
 		var valueIsBorderBox = true,
 			val = name === "width" ? elem.offsetWidth : elem.offsetHeight,
 			styles = getStyles( elem ),
 			isBorderBox = jQuery.support.boxSizing && jQuery.css( elem, "boxSizing", false, styles ) === "border-box";
-	
+
 		// some non-html elements return undefined for offsetWidth, so check for null/undefined
 		// svg - https://bugzilla.mozilla.org/show_bug.cgi?id=649285
 		// MathML - https://bugzilla.mozilla.org/show_bug.cgi?id=491668
@@ -7987,20 +7988,20 @@
 			if ( val < 0 || val == null ) {
 				val = elem.style[ name ];
 			}
-	
+
 			// Computed unit is not pixels. Stop here and return.
 			if ( rnumnonpx.test(val) ) {
 				return val;
 			}
-	
+
 			// we need the check for style in case a browser which returns unreliable values
 			// for getComputedStyle silently falls back to the reliable elem.style
 			valueIsBorderBox = isBorderBox && ( jQuery.support.boxSizingReliable || val === elem.style[ name ] );
-	
+
 			// Normalize "", auto, and prepare for extra
 			val = parseFloat( val ) || 0;
 		}
-	
+
 		// use the active box-sizing model to add/subtract irrelevant styles
 		return ( val +
 			augmentWidthOrHeight(
@@ -8012,15 +8013,15 @@
 			)
 		) + "px";
 	}
-	
+
 	// Try to determine the default display value of an element
 	function css_defaultDisplay( nodeName ) {
 		var doc = document,
 			display = elemdisplay[ nodeName ];
-	
+
 		if ( !display ) {
 			display = actualDisplay( nodeName, doc );
-	
+
 			// If the simple way fails, read from inside an iframe
 			if ( display === "none" || !display ) {
 				// Use the already-created iframe if possible
@@ -8028,23 +8029,23 @@
 					jQuery("<iframe frameborder='0' width='0' height='0'/>")
 					.css( "cssText", "display:block !important" )
 				).appendTo( doc.documentElement );
-	
+
 				// Always write a new HTML skeleton so Webkit and Firefox don't choke on reuse
 				doc = ( iframe[0].contentWindow || iframe[0].contentDocument ).document;
 				doc.write("<!doctype html><html><body>");
 				doc.close();
-	
+
 				display = actualDisplay( nodeName, doc );
 				iframe.detach();
 			}
-	
+
 			// Store the correct default display
 			elemdisplay[ nodeName ] = display;
 		}
-	
+
 		return display;
 	}
-	
+
 	// Called ONLY from within css_defaultDisplay
 	function actualDisplay( name, doc ) {
 		var elem = jQuery( doc.createElement( name ) ).appendTo( doc.body ),
@@ -8052,7 +8053,7 @@
 		elem.remove();
 		return display;
 	}
-	
+
 	jQuery.each([ "height", "width" ], function( i, name ) {
 		jQuery.cssHooks[ name ] = {
 			get: function( elem, computed, extra ) {
@@ -8066,7 +8067,7 @@
 						getWidthOrHeight( elem, name, extra );
 				}
 			},
-	
+
 			set: function( elem, value, extra ) {
 				var styles = extra && getStyles( elem );
 				return setPositiveNumber( elem, value, extra ?
@@ -8081,7 +8082,7 @@
 			}
 		};
 	});
-	
+
 	// These hooks cannot be added until DOM ready because the support test
 	// for it is not run until after DOM ready
 	jQuery(function() {
@@ -8099,7 +8100,7 @@
 				}
 			};
 		}
-	
+
 		// Webkit bug: https://bugs.webkit.org/show_bug.cgi?id=29084
 		// getComputedStyle returns percent when specified for top/left/bottom/right
 		// rather than make the css module depend on the offset module, we just check for it here
@@ -8118,21 +8119,21 @@
 				};
 			});
 		}
-	
+
 	});
-	
+
 	if ( jQuery.expr && jQuery.expr.filters ) {
 		jQuery.expr.filters.hidden = function( elem ) {
 			// Support: Opera <= 12.12
 			// Opera reports offsetWidths and offsetHeights less than zero on some elements
 			return elem.offsetWidth <= 0 && elem.offsetHeight <= 0;
 		};
-	
+
 		jQuery.expr.filters.visible = function( elem ) {
 			return !jQuery.expr.filters.hidden( elem );
 		};
 	}
-	
+
 	// These hooks are used by animate to expand properties
 	jQuery.each({
 		margin: "",
@@ -8143,19 +8144,19 @@
 			expand: function( value ) {
 				var i = 0,
 					expanded = {},
-	
+
 					// assumes a single number if not a string
 					parts = typeof value === "string" ? value.split(" ") : [ value ];
-	
+
 				for ( ; i < 4; i++ ) {
 					expanded[ prefix + cssExpand[ i ] + suffix ] =
 						parts[ i ] || parts[ i - 2 ] || parts[ 0 ];
 				}
-	
+
 				return expanded;
 			}
 		};
-	
+
 		if ( !rmargin.test( prefix ) ) {
 			jQuery.cssHooks[ prefix + suffix ].set = setPositiveNumber;
 		}
@@ -8165,7 +8166,7 @@
 		rCRLF = /\r?\n/g,
 		rsubmitterTypes = /^(?:submit|button|image|reset|file)$/i,
 		rsubmittable = /^(?:input|select|textarea|keygen)/i;
-	
+
 	jQuery.fn.extend({
 		serialize: function() {
 			return jQuery.param( this.serializeArray() );
@@ -8185,7 +8186,7 @@
 			})
 			.map(function( i, elem ){
 				var val = jQuery( this ).val();
-	
+
 				return val == null ?
 					null :
 					jQuery.isArray( val ) ?
@@ -8196,7 +8197,7 @@
 			}).get();
 		}
 	});
-	
+
 	//Serialize an array of form elements or a set of
 	//key/values into a query string
 	jQuery.param = function( a, traditional ) {
@@ -8207,19 +8208,19 @@
 				value = jQuery.isFunction( value ) ? value() : ( value == null ? "" : value );
 				s[ s.length ] = encodeURIComponent( key ) + "=" + encodeURIComponent( value );
 			};
-	
+
 		// Set traditional to true for jQuery <= 1.3.2 behavior.
 		if ( traditional === undefined ) {
 			traditional = jQuery.ajaxSettings && jQuery.ajaxSettings.traditional;
 		}
-	
+
 		// If an array was passed in, assume that it is an array of form elements.
 		if ( jQuery.isArray( a ) || ( a.jquery && !jQuery.isPlainObject( a ) ) ) {
 			// Serialize the form elements
 			jQuery.each( a, function() {
 				add( this.name, this.value );
 			});
-	
+
 		} else {
 			// If traditional, encode the "old" way (the way 1.3.2 or older
 			// did it), otherwise encode params recursively.
@@ -8227,33 +8228,33 @@
 				buildParams( prefix, a[ prefix ], traditional, add );
 			}
 		}
-	
+
 		// Return the resulting serialization
 		return s.join( "&" ).replace( r20, "+" );
 	};
-	
+
 	function buildParams( prefix, obj, traditional, add ) {
 		var name;
-	
+
 		if ( jQuery.isArray( obj ) ) {
 			// Serialize array item.
 			jQuery.each( obj, function( i, v ) {
 				if ( traditional || rbracket.test( prefix ) ) {
 					// Treat each array item as a scalar.
 					add( prefix, v );
-	
+
 				} else {
 					// Item is non-scalar (array or object), encode its numeric index.
 					buildParams( prefix + "[" + ( typeof v === "object" ? i : "" ) + "]", v, traditional, add );
 				}
 			});
-	
+
 		} else if ( !traditional && jQuery.type( obj ) === "object" ) {
 			// Serialize object item.
 			for ( name in obj ) {
 				buildParams( prefix + "[" + name + "]", obj[ name ], traditional, add );
 			}
-	
+
 		} else {
 			// Serialize scalar item.
 			add( prefix, obj );
@@ -8262,7 +8263,7 @@
 	jQuery.each( ("blur focus focusin focusout load resize scroll unload click dblclick " +
 		"mousedown mouseup mousemove mouseover mouseout mouseenter mouseleave " +
 		"change select submit keydown keypress keyup error contextmenu").split(" "), function( i, name ) {
-	
+
 		// Handle event binding
 		jQuery.fn[ name ] = function( data, fn ) {
 			return arguments.length > 0 ?
@@ -8270,19 +8271,19 @@
 				this.trigger( name );
 		};
 	});
-	
+
 	jQuery.fn.extend({
 		hover: function( fnOver, fnOut ) {
 			return this.mouseenter( fnOver ).mouseleave( fnOut || fnOver );
 		},
-	
+
 		bind: function( types, data, fn ) {
 			return this.on( types, null, data, fn );
 		},
 		unbind: function( types, fn ) {
 			return this.off( types, null, fn );
 		},
-	
+
 		delegate: function( selector, types, data, fn ) {
 			return this.on( types, selector, data, fn );
 		},
@@ -8295,9 +8296,9 @@
 		// Document location
 		ajaxLocParts,
 		ajaxLocation,
-	
+
 		ajax_nonce = jQuery.now(),
-	
+
 		ajax_rquery = /\?/,
 		rhash = /#.*$/,
 		rts = /([?&])_=[^&]*/,
@@ -8307,10 +8308,10 @@
 		rnoContent = /^(?:GET|HEAD)$/,
 		rprotocol = /^\/\//,
 		rurl = /^([\w.+-]+:)(?:\/\/([^\/?#:]*)(?::(\d+)|)|)/,
-	
+
 		// Keep a copy of the old load method
 		_load = jQuery.fn.load,
-	
+
 		/* Prefilters
 		 * 1) They are useful to introduce custom dataTypes (see ajax/jsonp.js for an example)
 		 * 2) These are called:
@@ -8321,17 +8322,17 @@
 		 * 5) execution will start with transport dataType and THEN continue down to "*" if needed
 		 */
 		prefilters = {},
-	
+
 		/* Transports bindings
 		 * 1) key is the dataType
 		 * 2) the catchall symbol "*" can be used
 		 * 3) selection will start with transport dataType and THEN go to "*" if needed
 		 */
 		transports = {},
-	
+
 		// Avoid comment-prolog char sequence (#10098); must appease lint and evade compression
 		allTypes = "*/".concat("*");
-	
+
 	// #8138, IE may throw an exception when accessing
 	// a field from window.location if document.domain has been set
 	try {
@@ -8343,25 +8344,25 @@
 		ajaxLocation.href = "";
 		ajaxLocation = ajaxLocation.href;
 	}
-	
+
 	// Segment location into parts
 	ajaxLocParts = rurl.exec( ajaxLocation.toLowerCase() ) || [];
-	
+
 	// Base "constructor" for jQuery.ajaxPrefilter and jQuery.ajaxTransport
 	function addToPrefiltersOrTransports( structure ) {
-	
+
 		// dataTypeExpression is optional and defaults to "*"
 		return function( dataTypeExpression, func ) {
-	
+
 			if ( typeof dataTypeExpression !== "string" ) {
 				func = dataTypeExpression;
 				dataTypeExpression = "*";
 			}
-	
+
 			var dataType,
 				i = 0,
 				dataTypes = dataTypeExpression.toLowerCase().match( core_rnotwhite ) || [];
-	
+
 			if ( jQuery.isFunction( func ) ) {
 				// For each dataType in the dataTypeExpression
 				while ( (dataType = dataTypes[i++]) ) {
@@ -8369,7 +8370,7 @@
 					if ( dataType[0] === "+" ) {
 						dataType = dataType.slice( 1 ) || "*";
 						(structure[ dataType ] = structure[ dataType ] || []).unshift( func );
-	
+
 					// Otherwise append
 					} else {
 						(structure[ dataType ] = structure[ dataType ] || []).push( func );
@@ -8378,13 +8379,13 @@
 			}
 		};
 	}
-	
+
 	// Base inspection function for prefilters and transports
 	function inspectPrefiltersOrTransports( structure, options, originalOptions, jqXHR ) {
-	
+
 		var inspected = {},
 			seekingTransport = ( structure === transports );
-	
+
 		function inspect( dataType ) {
 			var selected;
 			inspected[ dataType ] = true;
@@ -8400,17 +8401,17 @@
 			});
 			return selected;
 		}
-	
+
 		return inspect( options.dataTypes[ 0 ] ) || !inspected[ "*" ] && inspect( "*" );
 	}
-	
+
 	// A special extend for ajax options
 	// that takes "flat" options (not to be deep extended)
 	// Fixes #9887
 	function ajaxExtend( target, src ) {
 		var key, deep,
 			flatOptions = jQuery.ajaxSettings.flatOptions || {};
-	
+
 		for ( key in src ) {
 			if ( src[ key ] !== undefined ) {
 				( flatOptions[ key ] ? target : ( deep || (deep = {}) ) )[ key ] = src[ key ];
@@ -8419,83 +8420,83 @@
 		if ( deep ) {
 			jQuery.extend( true, target, deep );
 		}
-	
+
 		return target;
 	}
-	
+
 	jQuery.fn.load = function( url, params, callback ) {
 		if ( typeof url !== "string" && _load ) {
 			return _load.apply( this, arguments );
 		}
-	
+
 		var selector, type, response,
 			self = this,
 			off = url.indexOf(" ");
-	
+
 		if ( off >= 0 ) {
 			selector = url.slice( off );
 			url = url.slice( 0, off );
 		}
-	
+
 		// If it's a function
 		if ( jQuery.isFunction( params ) ) {
-	
+
 			// We assume that it's the callback
 			callback = params;
 			params = undefined;
-	
+
 		// Otherwise, build a param string
 		} else if ( params && typeof params === "object" ) {
 			type = "POST";
 		}
-	
+
 		// If we have elements to modify, make the request
 		if ( self.length > 0 ) {
 			jQuery.ajax({
 				url: url,
-	
+
 				// if "type" variable is undefined, then "GET" method will be used
 				type: type,
 				dataType: "html",
 				data: params
 			}).done(function( responseText ) {
-	
+
 				// Save response for use in complete callback
 				response = arguments;
-	
+
 				self.html( selector ?
-	
+
 					// If a selector was specified, locate the right elements in a dummy div
 					// Exclude scripts to avoid IE 'Permission Denied' errors
 					jQuery("<div>").append( jQuery.parseHTML( responseText ) ).find( selector ) :
-	
+
 					// Otherwise use the full result
 					responseText );
-	
+
 			}).complete( callback && function( jqXHR, status ) {
 				self.each( callback, response || [ jqXHR.responseText, status, jqXHR ] );
 			});
 		}
-	
+
 		return this;
 	};
-	
+
 	// Attach a bunch of functions for handling common AJAX events
 	jQuery.each( [ "ajaxStart", "ajaxStop", "ajaxComplete", "ajaxError", "ajaxSuccess", "ajaxSend" ], function( i, type ){
 		jQuery.fn[ type ] = function( fn ){
 			return this.on( type, fn );
 		};
 	});
-	
+
 	jQuery.extend({
-	
+
 		// Counter for holding the number of active queries
 		active: 0,
-	
+
 		// Last-Modified header cache for next request
 		lastModified: {},
 		etag: {},
-	
+
 		ajaxSettings: {
 			url: ajaxLocation,
 			type: "GET",
@@ -8515,7 +8516,7 @@
 			traditional: false,
 			headers: {},
 			*/
-	
+
 			accepts: {
 				"*": allTypes,
 				text: "text/plain",
@@ -8523,36 +8524,36 @@
 				xml: "application/xml, text/xml",
 				json: "application/json, text/javascript"
 			},
-	
+
 			contents: {
 				xml: /xml/,
 				html: /html/,
 				json: /json/
 			},
-	
+
 			responseFields: {
 				xml: "responseXML",
 				text: "responseText",
 				json: "responseJSON"
 			},
-	
+
 			// Data converters
 			// Keys separate source (or catchall "*") and destination types with a single space
 			converters: {
-	
+
 				// Convert anything to text
 				"* text": String,
-	
+
 				// Text to html (true = no transformation)
 				"text html": true,
-	
+
 				// Evaluate text as a json expression
 				"text json": jQuery.parseJSON,
-	
+
 				// Parse text as xml
 				"text xml": jQuery.parseXML
 			},
-	
+
 			// For options that shouldn't be deep extended:
 			// you can add your own custom options here if
 			// and when you create one that shouldn't be
@@ -8562,35 +8563,35 @@
 				context: true
 			}
 		},
-	
+
 		// Creates a full fledged settings object into target
 		// with both ajaxSettings and settings fields.
 		// If target is omitted, writes into ajaxSettings.
 		ajaxSetup: function( target, settings ) {
 			return settings ?
-	
+
 				// Building a settings object
 				ajaxExtend( ajaxExtend( target, jQuery.ajaxSettings ), settings ) :
-	
+
 				// Extending ajaxSettings
 				ajaxExtend( jQuery.ajaxSettings, target );
 		},
-	
+
 		ajaxPrefilter: addToPrefiltersOrTransports( prefilters ),
 		ajaxTransport: addToPrefiltersOrTransports( transports ),
-	
+
 		// Main method
 		ajax: function( url, options ) {
-	
+
 			// If url is an object, simulate pre-1.5 signature
 			if ( typeof url === "object" ) {
 				options = url;
 				url = undefined;
 			}
-	
+
 			// Force options to be an object
 			options = options || {};
-	
+
 			var transport,
 				// URL without anti-cache param
 				cacheURL,
@@ -8628,7 +8629,7 @@
 				// Fake xhr
 				jqXHR = {
 					readyState: 0,
-	
+
 					// Builds headers hashtable if needed
 					getResponseHeader: function( key ) {
 						var match;
@@ -8643,12 +8644,12 @@
 						}
 						return match == null ? null : match;
 					},
-	
+
 					// Raw string
 					getAllResponseHeaders: function() {
 						return state === 2 ? responseHeadersString : null;
 					},
-	
+
 					// Caches the header
 					setRequestHeader: function( name, value ) {
 						var lname = name.toLowerCase();
@@ -8658,7 +8659,7 @@
 						}
 						return this;
 					},
-	
+
 					// Overrides response content-type header
 					overrideMimeType: function( type ) {
 						if ( !state ) {
@@ -8666,7 +8667,7 @@
 						}
 						return this;
 					},
-	
+
 					// Status-dependent callbacks
 					statusCode: function( map ) {
 						var code;
@@ -8683,7 +8684,7 @@
 						}
 						return this;
 					},
-	
+
 					// Cancel the request
 					abort: function( statusText ) {
 						var finalText = statusText || strAbort;
@@ -8694,25 +8695,25 @@
 						return this;
 					}
 				};
-	
+
 			// Attach deferreds
 			deferred.promise( jqXHR ).complete = completeDeferred.add;
 			jqXHR.success = jqXHR.done;
 			jqXHR.error = jqXHR.fail;
-	
+
 			// Remove hash character (#7531: and string promotion)
 			// Add protocol if not provided (prefilters might expect it)
 			// Handle falsy url in the settings object (#10093: consistency with old signature)
 			// We also use the url parameter if available
 			s.url = ( ( url || s.url || ajaxLocation ) + "" ).replace( rhash, "" )
 				.replace( rprotocol, ajaxLocParts[ 1 ] + "//" );
-	
+
 			// Alias method option to type as per ticket #12004
 			s.type = options.method || options.type || s.method || s.type;
-	
+
 			// Extract dataTypes list
 			s.dataTypes = jQuery.trim( s.dataType || "*" ).toLowerCase().match( core_rnotwhite ) || [""];
-	
+
 			// A cross-domain request is in order when we have a protocol:host:port mismatch
 			if ( s.crossDomain == null ) {
 				parts = rurl.exec( s.url.toLowerCase() );
@@ -8722,60 +8723,60 @@
 							( ajaxLocParts[ 3 ] || ( ajaxLocParts[ 1 ] === "http:" ? "80" : "443" ) ) )
 				);
 			}
-	
+
 			// Convert data if not already a string
 			if ( s.data && s.processData && typeof s.data !== "string" ) {
 				s.data = jQuery.param( s.data, s.traditional );
 			}
-	
+
 			// Apply prefilters
 			inspectPrefiltersOrTransports( prefilters, s, options, jqXHR );
-	
+
 			// If request was aborted inside a prefilter, stop there
 			if ( state === 2 ) {
 				return jqXHR;
 			}
-	
+
 			// We can fire global events as of now if asked to
 			fireGlobals = s.global;
-	
+
 			// Watch for a new set of requests
 			if ( fireGlobals && jQuery.active++ === 0 ) {
 				jQuery.event.trigger("ajaxStart");
 			}
-	
+
 			// Uppercase the type
 			s.type = s.type.toUpperCase();
-	
+
 			// Determine if request has content
 			s.hasContent = !rnoContent.test( s.type );
-	
+
 			// Save the URL in case we're toying with the If-Modified-Since
 			// and/or If-None-Match header later on
 			cacheURL = s.url;
-	
+
 			// More options handling for requests with no content
 			if ( !s.hasContent ) {
-	
+
 				// If data is available, append data to url
 				if ( s.data ) {
 					cacheURL = ( s.url += ( ajax_rquery.test( cacheURL ) ? "&" : "?" ) + s.data );
 					// #9682: remove data so that it's not used in an eventual retry
 					delete s.data;
 				}
-	
+
 				// Add anti-cache in url if needed
 				if ( s.cache === false ) {
 					s.url = rts.test( cacheURL ) ?
-	
+
 						// If there is already a '_' parameter, set its value
 						cacheURL.replace( rts, "$1_=" + ajax_nonce++ ) :
-	
+
 						// Otherwise add one to the end
 						cacheURL + ( ajax_rquery.test( cacheURL ) ? "&" : "?" ) + "_=" + ajax_nonce++;
 				}
 			}
-	
+
 			// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
 			if ( s.ifModified ) {
 				if ( jQuery.lastModified[ cacheURL ] ) {
@@ -8785,12 +8786,12 @@
 					jqXHR.setRequestHeader( "If-None-Match", jQuery.etag[ cacheURL ] );
 				}
 			}
-	
+
 			// Set the correct header, if data is being sent
 			if ( s.data && s.hasContent && s.contentType !== false || options.contentType ) {
 				jqXHR.setRequestHeader( "Content-Type", s.contentType );
 			}
-	
+
 			// Set the Accepts header for the server, depending on the dataType
 			jqXHR.setRequestHeader(
 				"Accept",
@@ -8798,35 +8799,35 @@
 					s.accepts[ s.dataTypes[0] ] + ( s.dataTypes[ 0 ] !== "*" ? ", " + allTypes + "; q=0.01" : "" ) :
 					s.accepts[ "*" ]
 			);
-	
+
 			// Check for headers option
 			for ( i in s.headers ) {
 				jqXHR.setRequestHeader( i, s.headers[ i ] );
 			}
-	
+
 			// Allow custom headers/mimetypes and early abort
 			if ( s.beforeSend && ( s.beforeSend.call( callbackContext, jqXHR, s ) === false || state === 2 ) ) {
 				// Abort if not done already and return
 				return jqXHR.abort();
 			}
-	
+
 			// aborting is no longer a cancellation
 			strAbort = "abort";
-	
+
 			// Install callbacks on deferreds
 			for ( i in { success: 1, error: 1, complete: 1 } ) {
 				jqXHR[ i ]( s[ i ] );
 			}
-	
+
 			// Get transport
 			transport = inspectPrefiltersOrTransports( transports, s, options, jqXHR );
-	
+
 			// If no transport, we auto-abort
 			if ( !transport ) {
 				done( -1, "No Transport" );
 			} else {
 				jqXHR.readyState = 1;
-	
+
 				// Send global event
 				if ( fireGlobals ) {
 					globalEventContext.trigger( "ajaxSend", [ jqXHR, s ] );
@@ -8837,7 +8838,7 @@
 						jqXHR.abort("timeout");
 					}, s.timeout );
 				}
-	
+
 				try {
 					state = 1;
 					transport.send( requestHeaders, done );
@@ -8851,49 +8852,49 @@
 					}
 				}
 			}
-	
+
 			// Callback for when everything is done
 			function done( status, nativeStatusText, responses, headers ) {
 				var isSuccess, success, error, response, modified,
 					statusText = nativeStatusText;
-	
+
 				// Called once
 				if ( state === 2 ) {
 					return;
 				}
-	
+
 				// State is "done" now
 				state = 2;
-	
+
 				// Clear timeout if it exists
 				if ( timeoutTimer ) {
 					clearTimeout( timeoutTimer );
 				}
-	
+
 				// Dereference transport for early garbage collection
 				// (no matter how long the jqXHR object will be used)
 				transport = undefined;
-	
+
 				// Cache response headers
 				responseHeadersString = headers || "";
-	
+
 				// Set readyState
 				jqXHR.readyState = status > 0 ? 4 : 0;
-	
+
 				// Determine if successful
 				isSuccess = status >= 200 && status < 300 || status === 304;
-	
+
 				// Get response data
 				if ( responses ) {
 					response = ajaxHandleResponses( s, jqXHR, responses );
 				}
-	
+
 				// Convert no matter what (that way responseXXX fields are always set)
 				response = ajaxConvert( s, response, jqXHR, isSuccess );
-	
+
 				// If successful, handle type chaining
 				if ( isSuccess ) {
-	
+
 					// Set the If-Modified-Since and/or If-None-Match header, if in ifModified mode.
 					if ( s.ifModified ) {
 						modified = jqXHR.getResponseHeader("Last-Modified");
@@ -8905,15 +8906,15 @@
 							jQuery.etag[ cacheURL ] = modified;
 						}
 					}
-	
+
 					// if no content
 					if ( status === 204 || s.type === "HEAD" ) {
 						statusText = "nocontent";
-	
+
 					// if not modified
 					} else if ( status === 304 ) {
 						statusText = "notmodified";
-	
+
 					// If we have data, let's convert it
 					} else {
 						statusText = response.state;
@@ -8932,30 +8933,30 @@
 						}
 					}
 				}
-	
+
 				// Set data for the fake xhr object
 				jqXHR.status = status;
 				jqXHR.statusText = ( nativeStatusText || statusText ) + "";
-	
+
 				// Success/Error
 				if ( isSuccess ) {
 					deferred.resolveWith( callbackContext, [ success, statusText, jqXHR ] );
 				} else {
 					deferred.rejectWith( callbackContext, [ jqXHR, statusText, error ] );
 				}
-	
+
 				// Status-dependent callbacks
 				jqXHR.statusCode( statusCode );
 				statusCode = undefined;
-	
+
 				if ( fireGlobals ) {
 					globalEventContext.trigger( isSuccess ? "ajaxSuccess" : "ajaxError",
 						[ jqXHR, s, isSuccess ? success : error ] );
 				}
-	
+
 				// Complete
 				completeDeferred.fireWith( callbackContext, [ jqXHR, statusText ] );
-	
+
 				if ( fireGlobals ) {
 					globalEventContext.trigger( "ajaxComplete", [ jqXHR, s ] );
 					// Handle the global AJAX counter
@@ -8964,19 +8965,19 @@
 					}
 				}
 			}
-	
+
 			return jqXHR;
 		},
-	
+
 		getJSON: function( url, data, callback ) {
 			return jQuery.get( url, data, callback, "json" );
 		},
-	
+
 		getScript: function( url, callback ) {
 			return jQuery.get( url, undefined, callback, "script" );
 		}
 	});
-	
+
 	jQuery.each( [ "get", "post" ], function( i, method ) {
 		jQuery[ method ] = function( url, data, callback, type ) {
 			// shift arguments if data argument was omitted
@@ -8985,7 +8986,7 @@
 				callback = data;
 				data = undefined;
 			}
-	
+
 			return jQuery.ajax({
 				url: url,
 				type: method,
@@ -8995,17 +8996,17 @@
 			});
 		};
 	});
-	
+
 	/* Handles responses to an ajax request:
 	 * - finds the right dataType (mediates between content-type and expected dataType)
 	 * - returns the corresponding response
 	 */
 	function ajaxHandleResponses( s, jqXHR, responses ) {
-	
+
 		var ct, type, finalDataType, firstDataType,
 			contents = s.contents,
 			dataTypes = s.dataTypes;
-	
+
 		// Remove auto dataType and get content-type in the process
 		while( dataTypes[ 0 ] === "*" ) {
 			dataTypes.shift();
@@ -9013,7 +9014,7 @@
 				ct = s.mimeType || jqXHR.getResponseHeader("Content-Type");
 			}
 		}
-	
+
 		// Check if we're dealing with a known content-type
 		if ( ct ) {
 			for ( type in contents ) {
@@ -9023,7 +9024,7 @@
 				}
 			}
 		}
-	
+
 		// Check to see if we have a response for the expected dataType
 		if ( dataTypes[ 0 ] in responses ) {
 			finalDataType = dataTypes[ 0 ];
@@ -9041,7 +9042,7 @@
 			// Or just use first one
 			finalDataType = finalDataType || firstDataType;
 		}
-	
+
 		// If we found a dataType
 		// We add the dataType to the list if needed
 		// and return the corresponding response
@@ -9052,7 +9053,7 @@
 			return responses[ finalDataType ];
 		}
 	}
-	
+
 	/* Chain conversions given the request and the original response
 	 * Also sets the responseXXX fields on the jqXHR instance
 	 */
@@ -9061,52 +9062,52 @@
 			converters = {},
 			// Work with a copy of dataTypes in case we need to modify it for conversion
 			dataTypes = s.dataTypes.slice();
-	
+
 		// Create converters map with lowercased keys
 		if ( dataTypes[ 1 ] ) {
 			for ( conv in s.converters ) {
 				converters[ conv.toLowerCase() ] = s.converters[ conv ];
 			}
 		}
-	
+
 		current = dataTypes.shift();
-	
+
 		// Convert to each sequential dataType
 		while ( current ) {
-	
+
 			if ( s.responseFields[ current ] ) {
 				jqXHR[ s.responseFields[ current ] ] = response;
 			}
-	
+
 			// Apply the dataFilter if provided
 			if ( !prev && isSuccess && s.dataFilter ) {
 				response = s.dataFilter( response, s.dataType );
 			}
-	
+
 			prev = current;
 			current = dataTypes.shift();
-	
+
 			if ( current ) {
-	
+
 			// There's only work to do if current dataType is non-auto
 				if ( current === "*" ) {
-	
+
 					current = prev;
-	
+
 				// Convert response if prev dataType is non-auto and differs from current
 				} else if ( prev !== "*" && prev !== current ) {
-	
+
 					// Seek a direct converter
 					conv = converters[ prev + " " + current ] || converters[ "* " + current ];
-	
+
 					// If none found, seek a pair
 					if ( !conv ) {
 						for ( conv2 in converters ) {
-	
+
 							// If conv2 outputs current
 							tmp = conv2.split( " " );
 							if ( tmp[ 1 ] === current ) {
-	
+
 								// If prev can be converted to accepted input
 								conv = converters[ prev + " " + tmp[ 0 ] ] ||
 									converters[ "* " + tmp[ 0 ] ];
@@ -9114,7 +9115,7 @@
 									// Condense equivalence converters
 									if ( conv === true ) {
 										conv = converters[ conv2 ];
-	
+
 									// Otherwise, insert the intermediate dataType
 									} else if ( converters[ conv2 ] !== true ) {
 										current = tmp[ 0 ];
@@ -9125,10 +9126,10 @@
 							}
 						}
 					}
-	
+
 					// Apply converter (if not an equivalence)
 					if ( conv !== true ) {
-	
+
 						// Unless errors are allowed to bubble, catch and return them
 						if ( conv && s[ "throws" ] ) {
 							response = conv( response );
@@ -9143,7 +9144,7 @@
 				}
 			}
 		}
-	
+
 		return { state: "success", data: response };
 	}
 	// Install script dataType
@@ -9161,7 +9162,7 @@
 			}
 		}
 	});
-	
+
 	// Handle cache's special case and crossDomain
 	jQuery.ajaxPrefilter( "script", function( s ) {
 		if ( s.cache === undefined ) {
@@ -9171,7 +9172,7 @@
 			s.type = "GET";
 		}
 	});
-	
+
 	// Bind script tag hack transport
 	jQuery.ajaxTransport( "script", function( s ) {
 		// This transport only deals with cross domain requests
@@ -9205,7 +9206,7 @@
 	});
 	var oldCallbacks = [],
 		rjsonp = /(=)\?(?=&|$)|\?\?/;
-	
+
 	// Default jsonp settings
 	jQuery.ajaxSetup({
 		jsonp: "callback",
@@ -9215,31 +9216,31 @@
 			return callback;
 		}
 	});
-	
+
 	// Detect, normalize options and install callbacks for jsonp requests
 	jQuery.ajaxPrefilter( "json jsonp", function( s, originalSettings, jqXHR ) {
-	
+
 		var callbackName, overwritten, responseContainer,
 			jsonProp = s.jsonp !== false && ( rjsonp.test( s.url ) ?
 				"url" :
 				typeof s.data === "string" && !( s.contentType || "" ).indexOf("application/x-www-form-urlencoded") && rjsonp.test( s.data ) && "data"
 			);
-	
+
 		// Handle iff the expected data type is "jsonp" or we have a parameter to set
 		if ( jsonProp || s.dataTypes[ 0 ] === "jsonp" ) {
-	
+
 			// Get callback name, remembering preexisting value associated with it
 			callbackName = s.jsonpCallback = jQuery.isFunction( s.jsonpCallback ) ?
 				s.jsonpCallback() :
 				s.jsonpCallback;
-	
+
 			// Insert callback into url or form data
 			if ( jsonProp ) {
 				s[ jsonProp ] = s[ jsonProp ].replace( rjsonp, "$1" + callbackName );
 			} else if ( s.jsonp !== false ) {
 				s.url += ( ajax_rquery.test( s.url ) ? "&" : "?" ) + s.jsonp + "=" + callbackName;
 			}
-	
+
 			// Use data converter to retrieve json after script execution
 			s.converters["script json"] = function() {
 				if ( !responseContainer ) {
@@ -9247,38 +9248,38 @@
 				}
 				return responseContainer[ 0 ];
 			};
-	
+
 			// force json dataType
 			s.dataTypes[ 0 ] = "json";
-	
+
 			// Install callback
 			overwritten = window[ callbackName ];
 			window[ callbackName ] = function() {
 				responseContainer = arguments;
 			};
-	
+
 			// Clean-up function (fires after converters)
 			jqXHR.always(function() {
 				// Restore preexisting value
 				window[ callbackName ] = overwritten;
-	
+
 				// Save back as free
 				if ( s[ callbackName ] ) {
 					// make sure that re-using the options doesn't screw things around
 					s.jsonpCallback = originalSettings.jsonpCallback;
-	
+
 					// save the callback name for future use
 					oldCallbacks.push( callbackName );
 				}
-	
+
 				// Call if it was a function and we have a response
 				if ( responseContainer && jQuery.isFunction( overwritten ) ) {
 					overwritten( responseContainer[ 0 ] );
 				}
-	
+
 				responseContainer = overwritten = undefined;
 			});
-	
+
 			// Delegate to script
 			return "script";
 		}
@@ -9288,7 +9289,7 @@
 			return new XMLHttpRequest();
 		} catch( e ) {}
 	};
-	
+
 	var xhrSupported = jQuery.ajaxSettings.xhr(),
 		xhrSuccessStatus = {
 			// file protocol always yields status code 0, assume 200
@@ -9302,7 +9303,7 @@
 		// because IE is not smart enough to do it all by itself
 		xhrId = 0,
 		xhrCallbacks = {};
-	
+
 	if ( window.ActiveXObject ) {
 		jQuery( window ).on( "unload", function() {
 			for( var key in xhrCallbacks ) {
@@ -9311,10 +9312,10 @@
 			xhrCallbacks = undefined;
 		});
 	}
-	
+
 	jQuery.support.cors = !!xhrSupported && ( "withCredentials" in xhrSupported );
 	jQuery.support.ajax = xhrSupported = !!xhrSupported;
-	
+
 	jQuery.ajaxTransport(function( options ) {
 		var callback;
 		// Cross domain only allowed if supported through XMLHttpRequest
@@ -9405,37 +9406,37 @@
 					target = tween.cur(),
 					parts = rfxnum.exec( value ),
 					unit = parts && parts[ 3 ] || ( jQuery.cssNumber[ prop ] ? "" : "px" ),
-	
+
 					// Starting value computation is required for potential unit mismatches
 					start = ( jQuery.cssNumber[ prop ] || unit !== "px" && +target ) &&
 						rfxnum.exec( jQuery.css( tween.elem, prop ) ),
 					scale = 1,
 					maxIterations = 20;
-	
+
 				if ( start && start[ 3 ] !== unit ) {
 					// Trust units reported by jQuery.css
 					unit = unit || start[ 3 ];
-	
+
 					// Make sure we update the tween properties later on
 					parts = parts || [];
-	
+
 					// Iteratively approximate from a nonzero starting point
 					start = +target || 1;
-	
+
 					do {
 						// If previous iteration zeroed out, double until we get *something*
 						// Use a string for doubling factor so we don't accidentally see scale as unchanged below
 						scale = scale || ".5";
-	
+
 						// Adjust and apply
 						start = start / scale;
 						jQuery.style( tween.elem, prop, start + unit );
-	
+
 					// Update scale, tolerating zero or NaN from tween.cur()
 					// And breaking the loop if scale is unchanged or perfect, or if we've just had enough
 					} while ( scale !== (scale = tween.cur() / target) && scale !== 1 && --maxIterations );
 				}
-	
+
 				// Update tween properties
 				if ( parts ) {
 					start = tween.start = +start || +target || 0;
@@ -9445,11 +9446,11 @@
 						start + ( parts[ 1 ] + 1 ) * parts[ 2 ] :
 						+parts[ 2 ];
 				}
-	
+
 				return tween;
 			}]
 		};
-	
+
 	// Animations created synchronously will run synchronously
 	function createFxNow() {
 		setTimeout(function() {
@@ -9457,7 +9458,7 @@
 		});
 		return ( fxNow = jQuery.now() );
 	}
-	
+
 	function createTween( value, prop, animation ) {
 		var tween,
 			collection = ( tweeners[ prop ] || [] ).concat( tweeners[ "*" ] ),
@@ -9465,13 +9466,13 @@
 			length = collection.length;
 		for ( ; index < length; index++ ) {
 			if ( (tween = collection[ index ].call( animation, prop, value )) ) {
-	
+
 				// we're done with this property
 				return tween;
 			}
 		}
 	}
-	
+
 	function Animation( elem, properties, options ) {
 		var result,
 			stopped,
@@ -9492,13 +9493,13 @@
 					percent = 1 - temp,
 					index = 0,
 					length = animation.tweens.length;
-	
+
 				for ( ; index < length ; index++ ) {
 					animation.tweens[ index ].run( percent );
 				}
-	
+
 				deferred.notifyWith( elem, [ animation, percent, remaining ]);
-	
+
 				if ( percent < 1 && length ) {
 					return remaining;
 				} else {
@@ -9533,7 +9534,7 @@
 					for ( ; index < length ; index++ ) {
 						animation.tweens[ index ].run( 1 );
 					}
-	
+
 					// resolve when we played the last frame
 					// otherwise, reject
 					if ( gotoEnd ) {
@@ -9545,22 +9546,22 @@
 				}
 			}),
 			props = animation.props;
-	
+
 		propFilter( props, animation.opts.specialEasing );
-	
+
 		for ( ; index < length ; index++ ) {
 			result = animationPrefilters[ index ].call( animation, elem, props, animation.opts );
 			if ( result ) {
 				return result;
 			}
 		}
-	
+
 		jQuery.map( props, createTween, animation );
-	
+
 		if ( jQuery.isFunction( animation.opts.start ) ) {
 			animation.opts.start.call( elem, animation );
 		}
-	
+
 		jQuery.fx.timer(
 			jQuery.extend( tick, {
 				elem: elem,
@@ -9568,17 +9569,17 @@
 				queue: animation.opts.queue
 			})
 		);
-	
+
 		// attach callbacks from options
 		return animation.progress( animation.opts.progress )
 			.done( animation.opts.done, animation.opts.complete )
 			.fail( animation.opts.fail )
 			.always( animation.opts.always );
 	}
-	
+
 	function propFilter( props, specialEasing ) {
 		var index, name, easing, value, hooks;
-	
+
 		// camelCase, specialEasing and expand cssHook pass
 		for ( index in props ) {
 			name = jQuery.camelCase( index );
@@ -9588,17 +9589,17 @@
 				easing = value[ 1 ];
 				value = props[ index ] = value[ 0 ];
 			}
-	
+
 			if ( index !== name ) {
 				props[ name ] = value;
 				delete props[ index ];
 			}
-	
+
 			hooks = jQuery.cssHooks[ name ];
 			if ( hooks && "expand" in hooks ) {
 				value = hooks.expand( value );
 				delete props[ name ];
-	
+
 				// not quite $.extend, this wont overwrite keys already present.
 				// also - reusing 'index' from above because we have the correct "name"
 				for ( index in value ) {
@@ -9612,9 +9613,9 @@
 			}
 		}
 	}
-	
+
 	jQuery.Animation = jQuery.extend( Animation, {
-	
+
 		tweener: function( props, callback ) {
 			if ( jQuery.isFunction( props ) ) {
 				callback = props;
@@ -9622,18 +9623,18 @@
 			} else {
 				props = props.split(" ");
 			}
-	
+
 			var prop,
 				index = 0,
 				length = props.length;
-	
+
 			for ( ; index < length ; index++ ) {
 				prop = props[ index ];
 				tweeners[ prop ] = tweeners[ prop ] || [];
 				tweeners[ prop ].unshift( callback );
 			}
 		},
-	
+
 		prefilter: function( callback, prepend ) {
 			if ( prepend ) {
 				animationPrefilters.unshift( callback );
@@ -9642,7 +9643,7 @@
 			}
 		}
 	});
-	
+
 	function defaultPrefilter( elem, props, opts ) {
 		/* jshint validthis: true */
 		var prop, value, toggle, tween, hooks, oldfire,
@@ -9651,7 +9652,7 @@
 			style = elem.style,
 			hidden = elem.nodeType && isHidden( elem ),
 			dataShow = data_priv.get( elem, "fxshow" );
-	
+
 		// handle queue: false promises
 		if ( !opts.queue ) {
 			hooks = jQuery._queueHooks( elem, "fx" );
@@ -9665,7 +9666,7 @@
 				};
 			}
 			hooks.unqueued++;
-	
+
 			anim.always(function() {
 				// doing this makes sure that the complete handler will be called
 				// before this completes
@@ -9677,7 +9678,7 @@
 				});
 			});
 		}
-	
+
 		// height/width overflow pass
 		if ( elem.nodeType === 1 && ( "height" in props || "width" in props ) ) {
 			// Make sure that nothing sneaks out
@@ -9685,16 +9686,16 @@
 			// change the overflow attribute when overflowX and
 			// overflowY are set to the same value
 			opts.overflow = [ style.overflow, style.overflowX, style.overflowY ];
-	
+
 			// Set display property to inline-block for height/width
 			// animations on inline elements that are having width/height animated
 			if ( jQuery.css( elem, "display" ) === "inline" &&
 					jQuery.css( elem, "float" ) === "none" ) {
-	
+
 				style.display = "inline-block";
 			}
 		}
-	
+
 		if ( opts.overflow ) {
 			style.overflow = "hidden";
 			anim.always(function() {
@@ -9703,8 +9704,8 @@
 				style.overflowY = opts.overflow[ 2 ];
 			});
 		}
-	
-	
+
+
 		// show/hide pass
 		for ( prop in props ) {
 			value = props[ prop ];
@@ -9712,7 +9713,7 @@
 				delete props[ prop ];
 				toggle = toggle || value === "toggle";
 				if ( value === ( hidden ? "hide" : "show" ) ) {
-	
+
 					// If there is dataShow left over from a stopped hide or show and we are going to proceed with show, we should pretend to be hidden
 					if ( value === "show" && dataShow && dataShow[ prop ] !== undefined ) {
 						hidden = true;
@@ -9723,7 +9724,7 @@
 				orig[ prop ] = dataShow && dataShow[ prop ] || jQuery.style( elem, prop );
 			}
 		}
-	
+
 		if ( !jQuery.isEmptyObject( orig ) ) {
 			if ( dataShow ) {
 				if ( "hidden" in dataShow ) {
@@ -9732,7 +9733,7 @@
 			} else {
 				dataShow = data_priv.access( elem, "fxshow", {} );
 			}
-	
+
 			// store state if its toggle - enables .stop().toggle() to "reverse"
 			if ( toggle ) {
 				dataShow.hidden = !hidden;
@@ -9746,7 +9747,7 @@
 			}
 			anim.done(function() {
 				var prop;
-	
+
 				data_priv.remove( elem, "fxshow" );
 				for ( prop in orig ) {
 					jQuery.style( elem, prop, orig[ prop ] );
@@ -9754,7 +9755,7 @@
 			});
 			for ( prop in orig ) {
 				tween = createTween( hidden ? dataShow[ prop ] : 0, prop, anim );
-	
+
 				if ( !( prop in dataShow ) ) {
 					dataShow[ prop ] = tween.start;
 					if ( hidden ) {
@@ -9765,12 +9766,12 @@
 			}
 		}
 	}
-	
+
 	function Tween( elem, options, prop, end, easing ) {
 		return new Tween.prototype.init( elem, options, prop, end, easing );
 	}
 	jQuery.Tween = Tween;
-	
+
 	Tween.prototype = {
 		constructor: Tween,
 		init: function( elem, options, prop, end, easing, unit ) {
@@ -9784,7 +9785,7 @@
 		},
 		cur: function() {
 			var hooks = Tween.propHooks[ this.prop ];
-	
+
 			return hooks && hooks.get ?
 				hooks.get( this ) :
 				Tween.propHooks._default.get( this );
@@ -9792,7 +9793,7 @@
 		run: function( percent ) {
 			var eased,
 				hooks = Tween.propHooks[ this.prop ];
-	
+
 			if ( this.options.duration ) {
 				this.pos = eased = jQuery.easing[ this.easing ](
 					percent, this.options.duration * percent, 0, 1, this.options.duration
@@ -9801,11 +9802,11 @@
 				this.pos = eased = percent;
 			}
 			this.now = ( this.end - this.start ) * eased + this.start;
-	
+
 			if ( this.options.step ) {
 				this.options.step.call( this.elem, this.now, this );
 			}
-	
+
 			if ( hooks && hooks.set ) {
 				hooks.set( this );
 			} else {
@@ -9814,19 +9815,19 @@
 			return this;
 		}
 	};
-	
+
 	Tween.prototype.init.prototype = Tween.prototype;
-	
+
 	Tween.propHooks = {
 		_default: {
 			get: function( tween ) {
 				var result;
-	
+
 				if ( tween.elem[ tween.prop ] != null &&
 					(!tween.elem.style || tween.elem.style[ tween.prop ] == null) ) {
 					return tween.elem[ tween.prop ];
 				}
-	
+
 				// passing an empty string as a 3rd parameter to .css will automatically
 				// attempt a parseFloat and fallback to a string if the parse fails
 				// so, simple values such as "10px" are parsed to Float.
@@ -9848,10 +9849,10 @@
 			}
 		}
 	};
-	
+
 	// Support: IE9
 	// Panic based approach to setting things on disconnected nodes
-	
+
 	Tween.propHooks.scrollTop = Tween.propHooks.scrollLeft = {
 		set: function( tween ) {
 			if ( tween.elem.nodeType && tween.elem.parentNode ) {
@@ -9859,7 +9860,7 @@
 			}
 		}
 	};
-	
+
 	jQuery.each([ "toggle", "show", "hide" ], function( i, name ) {
 		var cssFn = jQuery.fn[ name ];
 		jQuery.fn[ name ] = function( speed, easing, callback ) {
@@ -9868,13 +9869,13 @@
 				this.animate( genFx( name, true ), speed, easing, callback );
 		};
 	});
-	
+
 	jQuery.fn.extend({
 		fadeTo: function( speed, to, easing, callback ) {
-	
+
 			// show any hidden elements after setting opacity to 0
 			return this.filter( isHidden ).css( "opacity", 0 ).show()
-	
+
 				// animate to the value specified
 				.end().animate({ opacity: to }, speed, easing, callback );
 		},
@@ -9884,14 +9885,14 @@
 				doAnimation = function() {
 					// Operate on a copy of prop so per-property easing won't be lost
 					var anim = Animation( this, jQuery.extend( {}, prop ), optall );
-	
+
 					// Empty animations, or finishing resolves immediately
 					if ( empty || data_priv.get( this, "finish" ) ) {
 						anim.stop( true );
 					}
 				};
 				doAnimation.finish = doAnimation;
-	
+
 			return empty || optall.queue === false ?
 				this.each( doAnimation ) :
 				this.queue( optall.queue, doAnimation );
@@ -9902,7 +9903,7 @@
 				delete hooks.stop;
 				stop( gotoEnd );
 			};
-	
+
 			if ( typeof type !== "string" ) {
 				gotoEnd = clearQueue;
 				clearQueue = type;
@@ -9911,13 +9912,13 @@
 			if ( clearQueue && type !== false ) {
 				this.queue( type || "fx", [] );
 			}
-	
+
 			return this.each(function() {
 				var dequeue = true,
 					index = type != null && type + "queueHooks",
 					timers = jQuery.timers,
 					data = data_priv.get( this );
-	
+
 				if ( index ) {
 					if ( data[ index ] && data[ index ].stop ) {
 						stopQueue( data[ index ] );
@@ -9929,7 +9930,7 @@
 						}
 					}
 				}
-	
+
 				for ( index = timers.length; index--; ) {
 					if ( timers[ index ].elem === this && (type == null || timers[ index ].queue === type) ) {
 						timers[ index ].anim.stop( gotoEnd );
@@ -9937,7 +9938,7 @@
 						timers.splice( index, 1 );
 					}
 				}
-	
+
 				// start the next in the queue if the last step wasn't forced
 				// timers currently will call their complete callbacks, which will dequeue
 				// but only if they were gotoEnd
@@ -9957,17 +9958,17 @@
 					hooks = data[ type + "queueHooks" ],
 					timers = jQuery.timers,
 					length = queue ? queue.length : 0;
-	
+
 				// enable finishing flag on private data
 				data.finish = true;
-	
+
 				// empty the queue first
 				jQuery.queue( this, type, [] );
-	
+
 				if ( hooks && hooks.stop ) {
 					hooks.stop.call( this, true );
 				}
-	
+
 				// look for any active animations, and finish them
 				for ( index = timers.length; index--; ) {
 					if ( timers[ index ].elem === this && timers[ index ].queue === type ) {
@@ -9975,26 +9976,26 @@
 						timers.splice( index, 1 );
 					}
 				}
-	
+
 				// look for any animations in the old queue and finish them
 				for ( index = 0; index < length; index++ ) {
 					if ( queue[ index ] && queue[ index ].finish ) {
 						queue[ index ].finish.call( this );
 					}
 				}
-	
+
 				// turn off finishing flag
 				delete data.finish;
 			});
 		}
 	});
-	
+
 	// Generate parameters to create a standard animation
 	function genFx( type, includeWidth ) {
 		var which,
 			attrs = { height: type },
 			i = 0;
-	
+
 		// if we include width, step value is 1 to do all cssExpand values,
 		// if we don't include width, step value is 2 to skip over Left and Right
 		includeWidth = includeWidth? 1 : 0;
@@ -10002,14 +10003,14 @@
 			which = cssExpand[ i ];
 			attrs[ "margin" + which ] = attrs[ "padding" + which ] = type;
 		}
-	
+
 		if ( includeWidth ) {
 			attrs.opacity = attrs.width = type;
 		}
-	
+
 		return attrs;
 	}
-	
+
 	// Generate shortcuts for custom animations
 	jQuery.each({
 		slideDown: genFx("show"),
@@ -10023,7 +10024,7 @@
 			return this.animate( props, speed, easing, callback );
 		};
 	});
-	
+
 	jQuery.speed = function( speed, easing, fn ) {
 		var opt = speed && typeof speed === "object" ? jQuery.extend( {}, speed ) : {
 			complete: fn || !fn && easing ||
@@ -10031,31 +10032,31 @@
 			duration: speed,
 			easing: fn && easing || easing && !jQuery.isFunction( easing ) && easing
 		};
-	
+
 		opt.duration = jQuery.fx.off ? 0 : typeof opt.duration === "number" ? opt.duration :
 			opt.duration in jQuery.fx.speeds ? jQuery.fx.speeds[ opt.duration ] : jQuery.fx.speeds._default;
-	
+
 		// normalize opt.queue - true/undefined/null -> "fx"
 		if ( opt.queue == null || opt.queue === true ) {
 			opt.queue = "fx";
 		}
-	
+
 		// Queueing
 		opt.old = opt.complete;
-	
+
 		opt.complete = function() {
 			if ( jQuery.isFunction( opt.old ) ) {
 				opt.old.call( this );
 			}
-	
+
 			if ( opt.queue ) {
 				jQuery.dequeue( this, opt.queue );
 			}
 		};
-	
+
 		return opt;
 	};
-	
+
 	jQuery.easing = {
 		linear: function( p ) {
 			return p;
@@ -10064,16 +10065,16 @@
 			return 0.5 - Math.cos( p*Math.PI ) / 2;
 		}
 	};
-	
+
 	jQuery.timers = [];
 	jQuery.fx = Tween.prototype.init;
 	jQuery.fx.tick = function() {
 		var timer,
 			timers = jQuery.timers,
 			i = 0;
-	
+
 		fxNow = jQuery.now();
-	
+
 		for ( ; i < timers.length; i++ ) {
 			timer = timers[ i ];
 			// Checks the timer has not already been removed
@@ -10081,42 +10082,42 @@
 				timers.splice( i--, 1 );
 			}
 		}
-	
+
 		if ( !timers.length ) {
 			jQuery.fx.stop();
 		}
 		fxNow = undefined;
 	};
-	
+
 	jQuery.fx.timer = function( timer ) {
 		if ( timer() && jQuery.timers.push( timer ) ) {
 			jQuery.fx.start();
 		}
 	};
-	
+
 	jQuery.fx.interval = 13;
-	
+
 	jQuery.fx.start = function() {
 		if ( !timerId ) {
 			timerId = setInterval( jQuery.fx.tick, jQuery.fx.interval );
 		}
 	};
-	
+
 	jQuery.fx.stop = function() {
 		clearInterval( timerId );
 		timerId = null;
 	};
-	
+
 	jQuery.fx.speeds = {
 		slow: 600,
 		fast: 200,
 		// Default speed
 		_default: 400
 	};
-	
+
 	// Back Compat <1.8 extension point
 	jQuery.fx.step = {};
-	
+
 	if ( jQuery.expr && jQuery.expr.filters ) {
 		jQuery.expr.filters.animated = function( elem ) {
 			return jQuery.grep(jQuery.timers, function( fn ) {
@@ -10132,23 +10133,23 @@
 					jQuery.offset.setOffset( this, options, i );
 				});
 		}
-	
+
 		var docElem, win,
 			elem = this[ 0 ],
 			box = { top: 0, left: 0 },
 			doc = elem && elem.ownerDocument;
-	
+
 		if ( !doc ) {
 			return;
 		}
-	
+
 		docElem = doc.documentElement;
-	
+
 		// Make sure it's not a disconnected DOM node
 		if ( !jQuery.contains( docElem, elem ) ) {
 			return box;
 		}
-	
+
 		// If we don't have gBCR, just use 0,0 rather than error
 		// BlackBerry 5, iOS 3 (original iPhone)
 		if ( typeof elem.getBoundingClientRect !== core_strundefined ) {
@@ -10160,134 +10161,134 @@
 			left: box.left + win.pageXOffset - docElem.clientLeft
 		};
 	};
-	
+
 	jQuery.offset = {
-	
+
 		setOffset: function( elem, options, i ) {
 			var curPosition, curLeft, curCSSTop, curTop, curOffset, curCSSLeft, calculatePosition,
 				position = jQuery.css( elem, "position" ),
 				curElem = jQuery( elem ),
 				props = {};
-	
+
 			// Set position first, in-case top/left are set even on static elem
 			if ( position === "static" ) {
 				elem.style.position = "relative";
 			}
-	
+
 			curOffset = curElem.offset();
 			curCSSTop = jQuery.css( elem, "top" );
 			curCSSLeft = jQuery.css( elem, "left" );
 			calculatePosition = ( position === "absolute" || position === "fixed" ) && ( curCSSTop + curCSSLeft ).indexOf("auto") > -1;
-	
+
 			// Need to be able to calculate position if either top or left is auto and position is either absolute or fixed
 			if ( calculatePosition ) {
 				curPosition = curElem.position();
 				curTop = curPosition.top;
 				curLeft = curPosition.left;
-	
+
 			} else {
 				curTop = parseFloat( curCSSTop ) || 0;
 				curLeft = parseFloat( curCSSLeft ) || 0;
 			}
-	
+
 			if ( jQuery.isFunction( options ) ) {
 				options = options.call( elem, i, curOffset );
 			}
-	
+
 			if ( options.top != null ) {
 				props.top = ( options.top - curOffset.top ) + curTop;
 			}
 			if ( options.left != null ) {
 				props.left = ( options.left - curOffset.left ) + curLeft;
 			}
-	
+
 			if ( "using" in options ) {
 				options.using.call( elem, props );
-	
+
 			} else {
 				curElem.css( props );
 			}
 		}
 	};
-	
-	
+
+
 	jQuery.fn.extend({
-	
+
 		position: function() {
 			if ( !this[ 0 ] ) {
 				return;
 			}
-	
+
 			var offsetParent, offset,
 				elem = this[ 0 ],
 				parentOffset = { top: 0, left: 0 };
-	
+
 			// Fixed elements are offset from window (parentOffset = {top:0, left: 0}, because it is it's only offset parent
 			if ( jQuery.css( elem, "position" ) === "fixed" ) {
 				// We assume that getBoundingClientRect is available when computed position is fixed
 				offset = elem.getBoundingClientRect();
-	
+
 			} else {
 				// Get *real* offsetParent
 				offsetParent = this.offsetParent();
-	
+
 				// Get correct offsets
 				offset = this.offset();
 				if ( !jQuery.nodeName( offsetParent[ 0 ], "html" ) ) {
 					parentOffset = offsetParent.offset();
 				}
-	
+
 				// Add offsetParent borders
 				parentOffset.top += jQuery.css( offsetParent[ 0 ], "borderTopWidth", true );
 				parentOffset.left += jQuery.css( offsetParent[ 0 ], "borderLeftWidth", true );
 			}
-	
+
 			// Subtract parent offsets and element margins
 			return {
 				top: offset.top - parentOffset.top - jQuery.css( elem, "marginTop", true ),
 				left: offset.left - parentOffset.left - jQuery.css( elem, "marginLeft", true )
 			};
 		},
-	
+
 		offsetParent: function() {
 			return this.map(function() {
 				var offsetParent = this.offsetParent || docElem;
-	
+
 				while ( offsetParent && ( !jQuery.nodeName( offsetParent, "html" ) && jQuery.css( offsetParent, "position") === "static" ) ) {
 					offsetParent = offsetParent.offsetParent;
 				}
-	
+
 				return offsetParent || docElem;
 			});
 		}
 	});
-	
-	
+
+
 	// Create scrollLeft and scrollTop methods
 	jQuery.each( {scrollLeft: "pageXOffset", scrollTop: "pageYOffset"}, function( method, prop ) {
 		var top = "pageYOffset" === prop;
-	
+
 		jQuery.fn[ method ] = function( val ) {
 			return jQuery.access( this, function( elem, method, val ) {
 				var win = getWindow( elem );
-	
+
 				if ( val === undefined ) {
 					return win ? win[ prop ] : elem[ method ];
 				}
-	
+
 				if ( win ) {
 					win.scrollTo(
 						!top ? val : window.pageXOffset,
 						top ? val : window.pageYOffset
 					);
-	
+
 				} else {
 					elem[ method ] = val;
 				}
 			}, method, val, arguments.length, null );
 		};
 	});
-	
+
 	function getWindow( elem ) {
 		return jQuery.isWindow( elem ) ? elem : elem.nodeType === 9 && elem.defaultView;
 	}
@@ -10298,21 +10299,21 @@
 			jQuery.fn[ funcName ] = function( margin, value ) {
 				var chainable = arguments.length && ( defaultExtra || typeof margin !== "boolean" ),
 					extra = defaultExtra || ( margin === true || value === true ? "margin" : "border" );
-	
+
 				return jQuery.access( this, function( elem, type, value ) {
 					var doc;
-	
+
 					if ( jQuery.isWindow( elem ) ) {
 						// As of 5/8/2012 this will yield incorrect results for Mobile Safari, but there
 						// isn't a whole lot we can do. See pull request at this URL for discussion:
 						// https://github.com/jquery/jquery/pull/764
 						return elem.document.documentElement[ "client" + name ];
 					}
-	
+
 					// Get document width or height
 					if ( elem.nodeType === 9 ) {
 						doc = elem.documentElement;
-	
+
 						// Either scroll[Width/Height] or offset[Width/Height] or client[Width/Height],
 						// whichever is greatest
 						return Math.max(
@@ -10321,11 +10322,11 @@
 							doc[ "client" + name ]
 						);
 					}
-	
+
 					return value === undefined ?
 						// Get width or height on the element, requesting but not forcing parseFloat
 						jQuery.css( elem, type, extra ) :
-	
+
 						// Set width or height on the element
 						jQuery.style( elem, type, value, extra );
 				}, type, chainable ? margin : undefined, chainable, null );
@@ -10334,14 +10335,14 @@
 	});
 	// Limit scope pollution from any deprecated API
 	// (function() {
-	
+
 	// The number of elements contained in the matched element set
 	jQuery.fn.size = function() {
 		return this.length;
 	};
-	
+
 	jQuery.fn.andSelf = jQuery.fn.addBack;
-	
+
 	// })();
 	if ( typeof module === "object" && module && typeof module.exports === "object" ) {
 		// Expose jQuery as module.exports in loaders that implement the Node
@@ -10357,152 +10358,115 @@
 		// derived from file names, and jQuery is normally delivered in a lowercase
 		// file name. Do this after creating the global so that if an AMD module wants
 		// to call noConflict to hide this version of jQuery, it will work.
-		if ( 'function' === "function" && (require(4)) ) {
-			{var __WEBPACK_AMD_DEFINE_ARRAY__ = []; var __WEBPACK_AMD_DEFINE_RESULT__ = (function () { return jQuery; }.apply(null, __WEBPACK_AMD_DEFINE_ARRAY__)); if(__WEBPACK_AMD_DEFINE_RESULT__ !== undefined) module.exports = __WEBPACK_AMD_DEFINE_RESULT__;};
+		if ( true ) {
+			(__WEBPACK_AMD_DEFINE_ARRAY__ = [], __WEBPACK_AMD_DEFINE_RESULT__ = (function () { return jQuery; }.apply(null, __WEBPACK_AMD_DEFINE_ARRAY__)), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
 		}
 	}
-	
+
 	// If there is a window object, that at least has a document property,
 	// define jQuery and $ identifiers
 	if ( typeof window === "object" && typeof window.document === "object" ) {
 		window.jQuery = window.$ = jQuery;
 	}
-	
+
 	})( window );
 	
-	/* WEBPACK VAR INJECTION */}(require, require(5)(module)))
+	/* WEBPACK VAR INJECTION */}.call(exports, require, require(4)(module)))
 
 /***/ },
-
-/***/ 3:
+/* 3 */
 /***/ function(module, exports, require) {
 
-	/*!
+	var __WEBPACK_AMD_DEFINE_ARRAY__, __WEBPACK_AMD_DEFINE_RESULT__;/*!
 	 * jQuery.ScrollTo
-	 * Copyright (c) 2007-2013 Ariel Flesler - aflesler<a>gmail<d>com | http://flesler.blogspot.com
-	 * Dual licensed under MIT and GPL.
-	 *
-	 * @projectDescription Easy element scrolling using jQuery.
+	 * Copyright (c) 2007-2014 Ariel Flesler - aflesler<a>gmail<d>com | http://flesler.blogspot.com
+	 * Licensed under MIT
 	 * http://flesler.blogspot.com/2007/10/jqueryscrollto.html
+	 * @projectDescription Easy element scrolling using jQuery.
 	 * @author Ariel Flesler
-	 * @version 1.4.6
-	 *
-	 * @id jQuery.scrollTo
-	 * @id jQuery.fn.scrollTo
-	 * @param {String, Number, DOMElement, jQuery, Object} target Where to scroll the matched elements.
-	 *	  The different options for target are:
-	 *		- A number position (will be applied to all axes).
-	 *		- A string position ('44', '100px', '+=90', etc ) will be applied to all axes
-	 *		- A jQuery/DOM element ( logically, child of the element to scroll )
-	 *		- A string selector, that will be relative to the element to scroll ( 'li:eq(2)', etc )
-	 *		- A hash { top:x, left:y }, x and y can be any kind of number/string like above.
-	 *		- A percentage of the container's dimension/s, for example: 50% to go to the middle.
-	 *		- The string 'max' for go-to-end. 
-	 * @param {Number, Function} duration The OVERALL length of the animation, this argument can be the settings object instead.
-	 * @param {Object,Function} settings Optional set of settings or the onAfter callback.
-	 *	 @option {String} axis Which axis must be scrolled, use 'x', 'y', 'xy' or 'yx'.
-	 *	 @option {Number, Function} duration The OVERALL length of the animation.
-	 *	 @option {String} easing The easing method for the animation.
-	 *	 @option {Boolean} margin If true, the margin of the target element will be deducted from the final position.
-	 *	 @option {Object, Number} offset Add/deduct from the end position. One number for both axes or { top:x, left:y }.
-	 *	 @option {Object, Number} over Add/deduct the height/width multiplied by 'over', can be { top:x, left:y } when using both axes.
-	 *	 @option {Boolean} queue If true, and both axis are given, the 2nd axis will only be animated after the first one ends.
-	 *	 @option {Function} onAfter Function to be called after the scrolling ends. 
-	 *	 @option {Function} onAfterFirst If queuing is activated, this function will be called after the first scrolling ends.
-	 * @return {jQuery} Returns the same jQuery object, for chaining.
-	 *
-	 * @desc Scroll to a fixed position
-	 * @example $('div').scrollTo( 340 );
-	 *
-	 * @desc Scroll relatively to the actual position
-	 * @example $('div').scrollTo( '+=340px', { axis:'y' } );
-	 *
-	 * @desc Scroll using a selector (relative to the scrolled element)
-	 * @example $('div').scrollTo( 'p.paragraph:eq(2)', 500, { easing:'swing', queue:true, axis:'xy' } );
-	 *
-	 * @desc Scroll to a DOM element (same for jQuery object)
-	 * @example var second_child = document.getElementById('container').firstChild.nextSibling;
-	 *			$('#container').scrollTo( second_child, { duration:500, axis:'x', onAfter:function(){
-	 *				alert('scrolled!!');																   
-	 *			}});
-	 *
-	 * @desc Scroll on both axes, to different values
-	 * @example $('div').scrollTo( { top: 300, left:'+=200' }, { axis:'xy', offset:-20 } );
+	 * @version 1.4.9
 	 */
-	
-	;(function( $ ){
-		
-		var $scrollTo = $.scrollTo = function( target, duration, settings ){
-			$(window).scrollTo( target, duration, settings );
+
+	;(function (factory) {
+	    // AMD Support
+	    if (true) {
+	        (__WEBPACK_AMD_DEFINE_ARRAY__ = [(require(2))], __WEBPACK_AMD_DEFINE_RESULT__ = (factory.apply(null, __WEBPACK_AMD_DEFINE_ARRAY__)), __WEBPACK_AMD_DEFINE_RESULT__ !== undefined && (module.exports = __WEBPACK_AMD_DEFINE_RESULT__));
+	    } else {
+	        factory(jQuery);
+	    }
+	}(function ($) {
+
+		var $scrollTo = $.scrollTo = function( target, duration, settings ) {
+			return $(window).scrollTo( target, duration, settings );
 		};
-	
+
 		$scrollTo.defaults = {
 			axis:'xy',
 			duration: parseFloat($.fn.jquery) >= 1.3 ? 0 : 1,
 			limit:true
 		};
-	
+
 		// Returns the element that needs to be animated to scroll the window.
 		// Kept for backwards compatibility (specially for localScroll & serialScroll)
-		$scrollTo.window = function( scope ){
+		$scrollTo.window = function( scope ) {
 			return $(window)._scrollable();
 		};
-	
+
 		// Hack, hack, hack :)
 		// Returns the real elements to scroll (supports window/iframes, documents and regular nodes)
-		$.fn._scrollable = function(){
-			return this.map(function(){
+		$.fn._scrollable = function() {
+			return this.map(function() {
 				var elem = this,
 					isWin = !elem.nodeName || $.inArray( elem.nodeName.toLowerCase(), ['iframe','#document','html','body'] ) != -1;
-	
-					if( !isWin )
+
+					if (!isWin)
 						return elem;
-	
+
 				var doc = (elem.contentWindow || elem).document || elem.ownerDocument || elem;
-				
+
 				return /webkit/i.test(navigator.userAgent) || doc.compatMode == 'BackCompat' ?
-					doc.body : 
+					doc.body :
 					doc.documentElement;
 			});
 		};
-	
-		$.fn.scrollTo = function( target, duration, settings ){
-			if( typeof duration == 'object' ){
+
+		$.fn.scrollTo = function( target, duration, settings ) {
+			if (typeof duration == 'object') {
 				settings = duration;
 				duration = 0;
 			}
-			if( typeof settings == 'function' )
+			if (typeof settings == 'function')
 				settings = { onAfter:settings };
-				
-			if( target == 'max' )
+
+			if (target == 'max')
 				target = 9e9;
-				
+
 			settings = $.extend( {}, $scrollTo.defaults, settings );
 			// Speed is still recognized for backwards compatibility
 			duration = duration || settings.duration;
 			// Make sure the settings are given right
 			settings.queue = settings.queue && settings.axis.length > 1;
-			
-			if( settings.queue )
+
+			if (settings.queue)
 				// Let's keep the overall duration
 				duration /= 2;
 			settings.offset = both( settings.offset );
 			settings.over = both( settings.over );
-	
-			return this._scrollable().each(function(){
+
+			return this._scrollable().each(function() {
 				// Null target yields nothing, just like jQuery does
 				if (target == null) return;
-	
+
 				var elem = this,
 					$elem = $(elem),
 					targ = target, toff, attr = {},
 					win = $elem.is('html,body');
-	
-				switch( typeof targ ){
+
+				switch (typeof targ) {
 					// A number will pass the regex
 					case 'number':
 					case 'string':
-						if( /^([+-]=?)?\d+(\.\d+)?(px|%)?$/.test(targ) ){
+						if (/^([+-]=?)?\d+(\.\d+)?(px|%)?$/.test(targ)) {
 							targ = both( targ );
 							// We are done
 							break;
@@ -10512,101 +10476,97 @@
 						if (!targ.length) return;
 					case 'object':
 						// DOMElement / jQuery
-						if( targ.is || targ.style )
-							// Get the real position of the target 
+						if (targ.is || targ.style)
+							// Get the real position of the target
 							toff = (targ = $(targ)).offset();
 				}
-				$.each( settings.axis.split(''), function( i, axis ){
+				
+				var offset = $.isFunction(settings.offset) && settings.offset(elem, targ) || settings.offset;
+				
+				$.each( settings.axis.split(''), function( i, axis ) {
 					var Pos	= axis == 'x' ? 'Left' : 'Top',
 						pos = Pos.toLowerCase(),
 						key = 'scroll' + Pos,
 						old = elem[key],
 						max = $scrollTo.max(elem, axis);
-	
-					if( toff ){// jQuery / DOMElement
+
+					if (toff) {// jQuery / DOMElement
 						attr[key] = toff[pos] + ( win ? 0 : old - $elem.offset()[pos] );
-	
+
 						// If it's a dom element, reduce the margin
-						if( settings.margin ){
+						if (settings.margin) {
 							attr[key] -= parseInt(targ.css('margin'+Pos)) || 0;
 							attr[key] -= parseInt(targ.css('border'+Pos+'Width')) || 0;
 						}
-						
-						attr[key] += settings.offset[pos] || 0;
-						
-						if( settings.over[pos] )
+
+						attr[key] += offset[pos] || 0;
+
+						if(settings.over[pos])
 							// Scroll to a fraction of its width/height
 							attr[key] += targ[axis=='x'?'width':'height']() * settings.over[pos];
-					}else{ 
+					} else {
 						var val = targ[pos];
 						// Handle percentage values
-						attr[key] = val.slice && val.slice(-1) == '%' ? 
+						attr[key] = val.slice && val.slice(-1) == '%' ?
 							parseFloat(val) / 100 * max
 							: val;
 					}
-	
+
 					// Number or 'number'
-					if( settings.limit && /^\d+$/.test(attr[key]) )
+					if (settings.limit && /^\d+$/.test(attr[key]))
 						// Check the limits
 						attr[key] = attr[key] <= 0 ? 0 : Math.min( attr[key], max );
-	
+
 					// Queueing axes
-					if( !i && settings.queue ){
+					if (!i && settings.queue) {
 						// Don't waste time animating, if there's no need.
-						if( old != attr[key] )
+						if (old != attr[key])
 							// Intermediate animation
 							animate( settings.onAfterFirst );
 						// Don't animate this axis again in the next iteration.
 						delete attr[key];
 					}
 				});
-	
-				animate( settings.onAfter );			
-	
-				function animate( callback ){
-					$elem.animate( attr, duration, settings.easing, callback && function(){
+
+				animate( settings.onAfter );
+
+				function animate( callback ) {
+					$elem.animate( attr, duration, settings.easing, callback && function() {
 						callback.call(this, targ, settings);
 					});
 				};
-	
+
 			}).end();
 		};
-		
+
 		// Max scrolling position, works on quirks mode
 		// It only fails (not too badly) on IE, quirks mode.
-		$scrollTo.max = function( elem, axis ){
+		$scrollTo.max = function( elem, axis ) {
 			var Dim = axis == 'x' ? 'Width' : 'Height',
 				scroll = 'scroll'+Dim;
-			
-			if( !$(elem).is('html,body') )
+
+			if (!$(elem).is('html,body'))
 				return elem[scroll] - $(elem)[Dim.toLowerCase()]();
-			
+
 			var size = 'client' + Dim,
 				html = elem.ownerDocument.documentElement,
 				body = elem.ownerDocument.body;
-	
-			return Math.max( html[scroll], body[scroll] ) 
+
+			return Math.max( html[scroll], body[scroll] )
 				 - Math.min( html[size]  , body[size]   );
 		};
-	
-		function both( val ){
-			return typeof val == 'object' ? val : { top:val, left:val };
+
+		function both( val ) {
+			return $.isFunction(val) || typeof val == 'object' ? val : { top:val, left:val };
 		};
-	
-	})( jQuery );
+
+	    // AMD requirement
+	    return $scrollTo;
+	}));
+
 
 /***/ },
-
-/***/ 4:
-/***/ function(module, exports, require) {
-
-	/* WEBPACK VAR INJECTION */(function(require, __webpack_amd_options__) {module.exports = __webpack_amd_options__;
-	
-	/* WEBPACK VAR INJECTION */}(require, {}))
-
-/***/ },
-
-/***/ 5:
+/* 4 */
 /***/ function(module, exports, require) {
 
 	module.exports = function(module) {
@@ -10619,39 +10579,38 @@
 		}
 		return module;
 	}
-	
+
 
 /***/ },
-
-/***/ 6:
+/* 5 */
 /***/ function(module, exports, require) {
 
 	//     Backbone.js 1.0.0
-	
+
 	//     (c) 2010-2013 Jeremy Ashkenas, DocumentCloud Inc.
 	//     Backbone may be freely distributed under the MIT license.
 	//     For all details and documentation:
 	//     http://backbonejs.org
-	
+
 	(function(){
-	
+
 	  // Initial Setup
 	  // -------------
-	
+
 	  // Save a reference to the global object (`window` in the browser, `exports`
 	  // on the server).
 	  var root = this;
-	
+
 	  // Save the previous value of the `Backbone` variable, so that it can be
 	  // restored later on, if `noConflict` is used.
 	  var previousBackbone = root.Backbone;
-	
+
 	  // Create local references to array methods we'll want to use later.
 	  var array = [];
 	  var push = array.push;
 	  var slice = array.slice;
 	  var splice = array.splice;
-	
+
 	  // The top-level namespace. All public Backbone classes and modules will
 	  // be attached to this. Exported for both the browser and the server.
 	  var Backbone;
@@ -10660,39 +10619,39 @@
 	  } else {
 	    Backbone = root.Backbone = {};
 	  }
-	
+
 	  // Current version of the library. Keep in sync with `package.json`.
 	  Backbone.VERSION = '1.0.0';
-	
+
 	  // Require Underscore, if we're on the server, and it's not already present.
 	  var _ = root._;
-	  if (!_ && ('function' !== 'undefined')) _ = require(8);
-	
+	  if (!_ && ('function' !== 'undefined')) _ = require(7);
+
 	  // For Backbone's purposes, jQuery, Zepto, Ender, or My Library (kidding) owns
 	  // the `$` variable.
 	  Backbone.$ = root.jQuery || root.Zepto || root.ender || root.$;
-	
+
 	  // Runs Backbone.js in *noConflict* mode, returning the `Backbone` variable
 	  // to its previous owner. Returns a reference to this Backbone object.
 	  Backbone.noConflict = function() {
 	    root.Backbone = previousBackbone;
 	    return this;
 	  };
-	
+
 	  // Turn on `emulateHTTP` to support legacy HTTP servers. Setting this option
 	  // will fake `"PUT"` and `"DELETE"` requests via the `_method` parameter and
 	  // set a `X-Http-Method-Override` header.
 	  Backbone.emulateHTTP = false;
-	
+
 	  // Turn on `emulateJSON` to support legacy servers that can't deal with direct
 	  // `application/json` requests ... will encode the body as
 	  // `application/x-www-form-urlencoded` instead and will send the model in a
 	  // form param named `model`.
 	  Backbone.emulateJSON = false;
-	
+
 	  // Backbone.Events
 	  // ---------------
-	
+
 	  // A module that can be mixed in to *any object* in order to provide it with
 	  // custom events. You may bind with `on` or remove with `off` callback
 	  // functions to an event; `trigger`-ing an event fires all callbacks in
@@ -10704,7 +10663,7 @@
 	  //     object.trigger('expand');
 	  //
 	  var Events = Backbone.Events = {
-	
+
 	    // Bind an event to a `callback` function. Passing `"all"` will bind
 	    // the callback to all events fired.
 	    on: function(name, callback, context) {
@@ -10714,7 +10673,7 @@
 	      events.push({callback: callback, context: context, ctx: context || this});
 	      return this;
 	    },
-	
+
 	    // Bind an event to only be triggered a single time. After the first time
 	    // the callback is invoked, it will be removed.
 	    once: function(name, callback, context) {
@@ -10727,7 +10686,7 @@
 	      once._callback = callback;
 	      return this.on(name, once, context);
 	    },
-	
+
 	    // Remove one or many callbacks. If `context` is null, removes all
 	    // callbacks with that function. If `callback` is null, removes all
 	    // callbacks for the event. If `name` is null, removes all bound
@@ -10739,7 +10698,7 @@
 	        this._events = {};
 	        return this;
 	      }
-	
+
 	      names = name ? [name] : _.keys(this._events);
 	      for (i = 0, l = names.length; i < l; i++) {
 	        name = names[i];
@@ -10757,10 +10716,10 @@
 	          if (!retain.length) delete this._events[name];
 	        }
 	      }
-	
+
 	      return this;
 	    },
-	
+
 	    // Trigger one or many events, firing all bound callbacks. Callbacks are
 	    // passed the same arguments as `trigger` is, apart from the event name
 	    // (unless you're listening on `"all"`, which will cause your callback to
@@ -10775,7 +10734,7 @@
 	      if (allEvents) triggerEvents(allEvents, arguments);
 	      return this;
 	    },
-	
+
 	    // Tell this object to stop listening to either specific events ... or
 	    // to every object it's currently listening to.
 	    stopListening: function(obj, name, callback) {
@@ -10790,18 +10749,18 @@
 	      }
 	      return this;
 	    }
-	
+
 	  };
-	
+
 	  // Regular expression used to split event strings.
 	  var eventSplitter = /\s+/;
-	
+
 	  // Implement fancy features of the Events API such as multiple event
 	  // names `"change blur"` and jQuery-style event maps `{change: action}`
 	  // in terms of the existing API.
 	  var eventsApi = function(obj, action, name, rest) {
 	    if (!name) return true;
-	
+
 	    // Handle event maps.
 	    if (typeof name === 'object') {
 	      for (var key in name) {
@@ -10809,7 +10768,7 @@
 	      }
 	      return false;
 	    }
-	
+
 	    // Handle space separated event names.
 	    if (eventSplitter.test(name)) {
 	      var names = name.split(eventSplitter);
@@ -10818,10 +10777,10 @@
 	      }
 	      return false;
 	    }
-	
+
 	    return true;
 	  };
-	
+
 	  // A difficult-to-believe, but optimized internal dispatch function for
 	  // triggering events. Tries to keep the usual cases speedy (most internal
 	  // Backbone events have 3 arguments).
@@ -10835,9 +10794,9 @@
 	      default: while (++i < l) (ev = events[i]).callback.apply(ev.ctx, args);
 	    }
 	  };
-	
+
 	  var listenMethods = {listenTo: 'on', listenToOnce: 'once'};
-	
+
 	  // Inversion-of-control versions of `on` and `once`. Tell *this* object to
 	  // listen to an event in another object ... keeping track of what it's
 	  // listening to.
@@ -10851,23 +10810,23 @@
 	      return this;
 	    };
 	  });
-	
+
 	  // Aliases for backwards compatibility.
 	  Events.bind   = Events.on;
 	  Events.unbind = Events.off;
-	
+
 	  // Allow the `Backbone` object to serve as a global event bus, for folks who
 	  // want global "pubsub" in a convenient place.
 	  _.extend(Backbone, Events);
-	
+
 	  // Backbone.Model
 	  // --------------
-	
+
 	  // Backbone **Models** are the basic data object in the framework --
 	  // frequently representing a row in a table in a database on your server.
 	  // A discrete chunk of data and a bunch of useful, related methods for
 	  // performing computations and transformations on that data.
-	
+
 	  // Create a new model with the specified attributes. A client id (`cid`)
 	  // is automatically generated and assigned for you.
 	  var Model = Backbone.Model = function(attributes, options) {
@@ -10885,61 +10844,61 @@
 	    this.changed = {};
 	    this.initialize.apply(this, arguments);
 	  };
-	
+
 	  // A list of options to be attached directly to the model, if provided.
 	  var modelOptions = ['url', 'urlRoot', 'collection'];
-	
+
 	  // Attach all inheritable methods to the Model prototype.
 	  _.extend(Model.prototype, Events, {
-	
+
 	    // A hash of attributes whose current and previous value differ.
 	    changed: null,
-	
+
 	    // The value returned during the last failed validation.
 	    validationError: null,
-	
+
 	    // The default name for the JSON `id` attribute is `"id"`. MongoDB and
 	    // CouchDB users may want to set this to `"_id"`.
 	    idAttribute: 'id',
-	
+
 	    // Initialize is an empty function by default. Override it with your own
 	    // initialization logic.
 	    initialize: function(){},
-	
+
 	    // Return a copy of the model's `attributes` object.
 	    toJSON: function(options) {
 	      return _.clone(this.attributes);
 	    },
-	
+
 	    // Proxy `Backbone.sync` by default -- but override this if you need
 	    // custom syncing semantics for *this* particular model.
 	    sync: function() {
 	      return Backbone.sync.apply(this, arguments);
 	    },
-	
+
 	    // Get the value of an attribute.
 	    get: function(attr) {
 	      return this.attributes[attr];
 	    },
-	
+
 	    // Get the HTML-escaped value of an attribute.
 	    escape: function(attr) {
 	      return _.escape(this.get(attr));
 	    },
-	
+
 	    // Returns `true` if the attribute contains a value that is not null
 	    // or undefined.
 	    has: function(attr) {
 	      return this.get(attr) != null;
 	    },
-	
+
 	    // Set a hash of model attributes on the object, firing `"change"`. This is
 	    // the core primitive operation of a model, updating the data and notifying
 	    // anyone who needs to know about the change in state. The heart of the beast.
 	    set: function(key, val, options) {
 	      var attr, attrs, unset, changes, silent, changing, prev, current;
 	      if (key == null) return this;
-	
+
 	      // Handle both `"key", value` and `{key: value}` -style arguments.
 	      if (typeof key === 'object') {
 	        attrs = key;
@@ -10947,28 +10906,28 @@
 	      } else {
 	        (attrs = {})[key] = val;
 	      }
-	
+
 	      options || (options = {});
-	
+
 	      // Run validation.
 	      if (!this._validate(attrs, options)) return false;
-	
+
 	      // Extract attributes and options.
 	      unset           = options.unset;
 	      silent          = options.silent;
 	      changes         = [];
 	      changing        = this._changing;
 	      this._changing  = true;
-	
+
 	      if (!changing) {
 	        this._previousAttributes = _.clone(this.attributes);
 	        this.changed = {};
 	      }
 	      current = this.attributes, prev = this._previousAttributes;
-	
+
 	      // Check for changes of `id`.
 	      if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
-	
+
 	      // For each `set` attribute, update or delete the current value.
 	      for (attr in attrs) {
 	        val = attrs[attr];
@@ -10980,7 +10939,7 @@
 	        }
 	        unset ? delete current[attr] : current[attr] = val;
 	      }
-	
+
 	      // Trigger all relevant attribute changes.
 	      if (!silent) {
 	        if (changes.length) this._pending = true;
@@ -10988,7 +10947,7 @@
 	          this.trigger('change:' + changes[i], this, current[changes[i]], options);
 	        }
 	      }
-	
+
 	      // You might be wondering why there's a `while` loop here. Changes can
 	      // be recursively nested within `"change"` events.
 	      if (changing) return this;
@@ -11002,27 +10961,27 @@
 	      this._changing = false;
 	      return this;
 	    },
-	
+
 	    // Remove an attribute from the model, firing `"change"`. `unset` is a noop
 	    // if the attribute doesn't exist.
 	    unset: function(attr, options) {
 	      return this.set(attr, void 0, _.extend({}, options, {unset: true}));
 	    },
-	
+
 	    // Clear all attributes on the model, firing `"change"`.
 	    clear: function(options) {
 	      var attrs = {};
 	      for (var key in this.attributes) attrs[key] = void 0;
 	      return this.set(attrs, _.extend({}, options, {unset: true}));
 	    },
-	
+
 	    // Determine if the model has changed since the last `"change"` event.
 	    // If you specify an attribute name, determine if that attribute has changed.
 	    hasChanged: function(attr) {
 	      if (attr == null) return !_.isEmpty(this.changed);
 	      return _.has(this.changed, attr);
 	    },
-	
+
 	    // Return an object containing all the attributes that have changed, or
 	    // false if there are no changed attributes. Useful for determining what
 	    // parts of a view need to be updated and/or what attributes need to be
@@ -11039,20 +10998,20 @@
 	      }
 	      return changed;
 	    },
-	
+
 	    // Get the previous value of an attribute, recorded at the time the last
 	    // `"change"` event was fired.
 	    previous: function(attr) {
 	      if (attr == null || !this._previousAttributes) return null;
 	      return this._previousAttributes[attr];
 	    },
-	
+
 	    // Get all of the attributes of the model at the time of the previous
 	    // `"change"` event.
 	    previousAttributes: function() {
 	      return _.clone(this._previousAttributes);
 	    },
-	
+
 	    // Fetch the model from the server. If the server's representation of the
 	    // model differs from its current attributes, they will be overridden,
 	    // triggering a `"change"` event.
@@ -11069,13 +11028,13 @@
 	      wrapError(this, options);
 	      return this.sync('read', this, options);
 	    },
-	
+
 	    // Set a hash of model attributes, and sync the model to the server.
 	    // If the server returns an attributes hash that differs, the model's
 	    // state will be `set` again.
 	    save: function(key, val, options) {
 	      var attrs, method, xhr, attributes = this.attributes;
-	
+
 	      // Handle both `"key", value` and `{key: value}` -style arguments.
 	      if (key == null || typeof key === 'object') {
 	        attrs = key;
@@ -11083,20 +11042,20 @@
 	      } else {
 	        (attrs = {})[key] = val;
 	      }
-	
+
 	      // If we're not waiting and attributes exist, save acts as `set(attr).save(null, opts)`.
 	      if (attrs && (!options || !options.wait) && !this.set(attrs, options)) return false;
-	
+
 	      options = _.extend({validate: true}, options);
-	
+
 	      // Do not persist invalid models.
 	      if (!this._validate(attrs, options)) return false;
-	
+
 	      // Set temporary attributes if `{wait: true}`.
 	      if (attrs && options.wait) {
 	        this.attributes = _.extend({}, attributes, attrs);
 	      }
-	
+
 	      // After a successful server-side save, the client is (optionally)
 	      // updated with the server-side state.
 	      if (options.parse === void 0) options.parse = true;
@@ -11114,17 +11073,17 @@
 	        model.trigger('sync', model, resp, options);
 	      };
 	      wrapError(this, options);
-	
+
 	      method = this.isNew() ? 'create' : (options.patch ? 'patch' : 'update');
 	      if (method === 'patch') options.attrs = attrs;
 	      xhr = this.sync(method, this, options);
-	
+
 	      // Restore attributes.
 	      if (attrs && options.wait) this.attributes = attributes;
-	
+
 	      return xhr;
 	    },
-	
+
 	    // Destroy this model on the server if it was already persisted.
 	    // Optimistically removes the model from its collection, if it has one.
 	    // If `wait: true` is passed, waits for the server to respond before removal.
@@ -11132,28 +11091,28 @@
 	      options = options ? _.clone(options) : {};
 	      var model = this;
 	      var success = options.success;
-	
+
 	      var destroy = function() {
 	        model.trigger('destroy', model, model.collection, options);
 	      };
-	
+
 	      options.success = function(resp) {
 	        if (options.wait || model.isNew()) destroy();
 	        if (success) success(model, resp, options);
 	        if (!model.isNew()) model.trigger('sync', model, resp, options);
 	      };
-	
+
 	      if (this.isNew()) {
 	        options.success();
 	        return false;
 	      }
 	      wrapError(this, options);
-	
+
 	      var xhr = this.sync('delete', this, options);
 	      if (!options.wait) destroy();
 	      return xhr;
 	    },
-	
+
 	    // Default URL for the model's representation on the server -- if you're
 	    // using Backbone's restful methods, override this to change the endpoint
 	    // that will be called.
@@ -11162,28 +11121,28 @@
 	      if (this.isNew()) return base;
 	      return base + (base.charAt(base.length - 1) === '/' ? '' : '/') + encodeURIComponent(this.id);
 	    },
-	
+
 	    // **parse** converts a response into the hash of attributes to be `set` on
 	    // the model. The default implementation is just to pass the response along.
 	    parse: function(resp, options) {
 	      return resp;
 	    },
-	
+
 	    // Create a new model with identical attributes to this one.
 	    clone: function() {
 	      return new this.constructor(this.attributes);
 	    },
-	
+
 	    // A model is new if it has never been saved to the server, and lacks an id.
 	    isNew: function() {
 	      return this.id == null;
 	    },
-	
+
 	    // Check if the model is currently in a valid state.
 	    isValid: function(options) {
 	      return this._validate({}, _.extend(options || {}, { validate: true }));
 	    },
-	
+
 	    // Run validation against the next complete set of model attributes,
 	    // returning `true` if all is well. Otherwise, fire an `"invalid"` event.
 	    _validate: function(attrs, options) {
@@ -11194,12 +11153,12 @@
 	      this.trigger('invalid', this, error, _.extend(options || {}, {validationError: error}));
 	      return false;
 	    }
-	
+
 	  });
-	
+
 	  // Underscore methods that we want to implement on the Model.
 	  var modelMethods = ['keys', 'values', 'pairs', 'invert', 'pick', 'omit'];
-	
+
 	  // Mix in each Underscore method as a proxy to `Model#attributes`.
 	  _.each(modelMethods, function(method) {
 	    Model.prototype[method] = function() {
@@ -11208,17 +11167,17 @@
 	      return _[method].apply(_, args);
 	    };
 	  });
-	
+
 	  // Backbone.Collection
 	  // -------------------
-	
+
 	  // If models tend to represent a single row of data, a Backbone Collection is
 	  // more analagous to a table full of data ... or a small slice or page of that
 	  // table, or a collection of rows that belong together for a particular reason
 	  // -- all of the messages in this particular folder, all of the documents
 	  // belonging to this particular author, and so on. Collections maintain
 	  // indexes of their models, both in order, and for lookup by `id`.
-	
+
 	  // Create a new **Collection**, perhaps to contain a specific type of `model`.
 	  // If a `comparator` is specified, the Collection will maintain
 	  // its models in sort order, as they're added and removed.
@@ -11231,38 +11190,38 @@
 	    this.initialize.apply(this, arguments);
 	    if (models) this.reset(models, _.extend({silent: true}, options));
 	  };
-	
+
 	  // Default options for `Collection#set`.
 	  var setOptions = {add: true, remove: true, merge: true};
 	  var addOptions = {add: true, merge: false, remove: false};
-	
+
 	  // Define the Collection's inheritable methods.
 	  _.extend(Collection.prototype, Events, {
-	
+
 	    // The default model for a collection is just a **Backbone.Model**.
 	    // This should be overridden in most cases.
 	    model: Model,
-	
+
 	    // Initialize is an empty function by default. Override it with your own
 	    // initialization logic.
 	    initialize: function(){},
-	
+
 	    // The JSON representation of a Collection is an array of the
 	    // models' attributes.
 	    toJSON: function(options) {
 	      return this.map(function(model){ return model.toJSON(options); });
 	    },
-	
+
 	    // Proxy `Backbone.sync` by default.
 	    sync: function() {
 	      return Backbone.sync.apply(this, arguments);
 	    },
-	
+
 	    // Add a model, or list of models to the set.
 	    add: function(models, options) {
 	      return this.set(models, _.defaults(options || {}, addOptions));
 	    },
-	
+
 	    // Remove a model, or a list of models from the set.
 	    remove: function(models, options) {
 	      models = _.isArray(models) ? models.slice() : [models];
@@ -11284,7 +11243,7 @@
 	      }
 	      return this;
 	    },
-	
+
 	    // Update a collection by `set`-ing a new list of models, adding new ones,
 	    // removing models that are no longer present, and merging models that
 	    // already exist in the collection, as necessary. Similar to **Model#set**,
@@ -11298,12 +11257,12 @@
 	      var sortable = this.comparator && (at == null) && options.sort !== false;
 	      var sortAttr = _.isString(this.comparator) ? this.comparator : null;
 	      var toAdd = [], toRemove = [], modelMap = {};
-	
+
 	      // Turn bare objects into model references, and prevent invalid models
 	      // from being added.
 	      for (i = 0, l = models.length; i < l; i++) {
 	        if (!(model = this._prepareModel(models[i], options))) continue;
-	
+
 	        // If a duplicate is found, prevent it from being added and
 	        // optionally merge it into the existing model.
 	        if (existing = this.get(model)) {
@@ -11312,11 +11271,11 @@
 	            existing.set(model.attributes, options);
 	            if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
 	          }
-	
+
 	        // This is a new model, push it to the `toAdd` list.
 	        } else if (options.add) {
 	          toAdd.push(model);
-	
+
 	          // Listen to added models' events, and index models for lookup by
 	          // `id` and by `cid`.
 	          model.on('all', this._onModelEvent, this);
@@ -11324,7 +11283,7 @@
 	          if (model.id != null) this._byId[model.id] = model;
 	        }
 	      }
-	
+
 	      // Remove nonexistent models if appropriate.
 	      if (options.remove) {
 	        for (i = 0, l = this.length; i < l; ++i) {
@@ -11332,7 +11291,7 @@
 	        }
 	        if (toRemove.length) this.remove(toRemove, options);
 	      }
-	
+
 	      // See if sorting is needed, update `length` and splice in new models.
 	      if (toAdd.length) {
 	        if (sortable) sort = true;
@@ -11343,22 +11302,22 @@
 	          push.apply(this.models, toAdd);
 	        }
 	      }
-	
+
 	      // Silently sort the collection if appropriate.
 	      if (sort) this.sort({silent: true});
-	
+
 	      if (options.silent) return this;
-	
+
 	      // Trigger `add` events.
 	      for (i = 0, l = toAdd.length; i < l; i++) {
 	        (model = toAdd[i]).trigger('add', model, this, options);
 	      }
-	
+
 	      // Trigger `sort` if the collection was sorted.
 	      if (sort) this.trigger('sort', this, options);
 	      return this;
 	    },
-	
+
 	    // When you have more items than you want to add or remove individually,
 	    // you can reset the entire set with a new list of models, without firing
 	    // any granular `add` or `remove` events. Fires `reset` when finished.
@@ -11374,51 +11333,51 @@
 	      if (!options.silent) this.trigger('reset', this, options);
 	      return this;
 	    },
-	
+
 	    // Add a model to the end of the collection.
 	    push: function(model, options) {
 	      model = this._prepareModel(model, options);
 	      this.add(model, _.extend({at: this.length}, options));
 	      return model;
 	    },
-	
+
 	    // Remove a model from the end of the collection.
 	    pop: function(options) {
 	      var model = this.at(this.length - 1);
 	      this.remove(model, options);
 	      return model;
 	    },
-	
+
 	    // Add a model to the beginning of the collection.
 	    unshift: function(model, options) {
 	      model = this._prepareModel(model, options);
 	      this.add(model, _.extend({at: 0}, options));
 	      return model;
 	    },
-	
+
 	    // Remove a model from the beginning of the collection.
 	    shift: function(options) {
 	      var model = this.at(0);
 	      this.remove(model, options);
 	      return model;
 	    },
-	
+
 	    // Slice out a sub-array of models from the collection.
 	    slice: function(begin, end) {
 	      return this.models.slice(begin, end);
 	    },
-	
+
 	    // Get a model from the set by id.
 	    get: function(obj) {
 	      if (obj == null) return void 0;
 	      return this._byId[obj.id != null ? obj.id : obj.cid || obj];
 	    },
-	
+
 	    // Get the model at the given index.
 	    at: function(index) {
 	      return this.models[index];
 	    },
-	
+
 	    // Return models with matching attributes. Useful for simple cases of
 	    // `filter`.
 	    where: function(attrs, first) {
@@ -11430,31 +11389,31 @@
 	        return true;
 	      });
 	    },
-	
+
 	    // Return the first model with matching attributes. Useful for simple cases
 	    // of `find`.
 	    findWhere: function(attrs) {
 	      return this.where(attrs, true);
 	    },
-	
+
 	    // Force the collection to re-sort itself. You don't need to call this under
 	    // normal circumstances, as the set will maintain sort order as each item
 	    // is added.
 	    sort: function(options) {
 	      if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
 	      options || (options = {});
-	
+
 	      // Run sort based on type of `comparator`.
 	      if (_.isString(this.comparator) || this.comparator.length === 1) {
 	        this.models = this.sortBy(this.comparator, this);
 	      } else {
 	        this.models.sort(_.bind(this.comparator, this));
 	      }
-	
+
 	      if (!options.silent) this.trigger('sort', this, options);
 	      return this;
 	    },
-	
+
 	    // Figure out the smallest index at which a model should be inserted so as
 	    // to maintain order.
 	    sortedIndex: function(model, value, context) {
@@ -11464,12 +11423,12 @@
 	      };
 	      return _.sortedIndex(this.models, model, iterator, context);
 	    },
-	
+
 	    // Pluck an attribute from each model in the collection.
 	    pluck: function(attr) {
 	      return _.invoke(this.models, 'get', attr);
 	    },
-	
+
 	    // Fetch the default set of models for this collection, resetting the
 	    // collection when they arrive. If `reset: true` is passed, the response
 	    // data will be passed through the `reset` method instead of `set`.
@@ -11487,7 +11446,7 @@
 	      wrapError(this, options);
 	      return this.sync('read', this, options);
 	    },
-	
+
 	    // Create a new instance of a model in this collection. Add the model to the
 	    // collection immediately, unless `wait: true` is passed, in which case we
 	    // wait for the server to agree.
@@ -11504,18 +11463,18 @@
 	      model.save(null, options);
 	      return model;
 	    },
-	
+
 	    // **parse** converts a response into a list of models to be added to the
 	    // collection. The default implementation is just to pass it through.
 	    parse: function(resp, options) {
 	      return resp;
 	    },
-	
+
 	    // Create a new collection with an identical list of models as this one.
 	    clone: function() {
 	      return new this.constructor(this.models);
 	    },
-	
+
 	    // Private method to reset all internal state. Called when the collection
 	    // is first initialized or reset.
 	    _reset: function() {
@@ -11523,7 +11482,7 @@
 	      this.models = [];
 	      this._byId  = {};
 	    },
-	
+
 	    // Prepare a hash of attributes (or other model) to be added to this
 	    // collection.
 	    _prepareModel: function(attrs, options) {
@@ -11540,13 +11499,13 @@
 	      }
 	      return model;
 	    },
-	
+
 	    // Internal method to sever a model's ties to a collection.
 	    _removeReference: function(model) {
 	      if (this === model.collection) delete model.collection;
 	      model.off('all', this._onModelEvent, this);
 	    },
-	
+
 	    // Internal method called every time a model in the set fires an event.
 	    // Sets need to update their indexes when models change ids. All other
 	    // events simply proxy through. "add" and "remove" events that originate
@@ -11560,9 +11519,9 @@
 	      }
 	      this.trigger.apply(this, arguments);
 	    }
-	
+
 	  });
-	
+
 	  // Underscore methods that we want to implement on the Collection.
 	  // 90% of the core usefulness of Backbone Collections is actually implemented
 	  // right here:
@@ -11572,7 +11531,7 @@
 	    'max', 'min', 'toArray', 'size', 'first', 'head', 'take', 'initial', 'rest',
 	    'tail', 'drop', 'last', 'without', 'indexOf', 'shuffle', 'lastIndexOf',
 	    'isEmpty', 'chain'];
-	
+
 	  // Mix in each Underscore method as a proxy to `Collection#models`.
 	  _.each(methods, function(method) {
 	    Collection.prototype[method] = function() {
@@ -11581,10 +11540,10 @@
 	      return _[method].apply(_, args);
 	    };
 	  });
-	
+
 	  // Underscore methods that take a property name as an argument.
 	  var attributeMethods = ['groupBy', 'countBy', 'sortBy'];
-	
+
 	  // Use attributes instead of properties.
 	  _.each(attributeMethods, function(method) {
 	    Collection.prototype[method] = function(value, context) {
@@ -11594,10 +11553,10 @@
 	      return _[method](this.models, iterator, context);
 	    };
 	  });
-	
+
 	  // Backbone.View
 	  // -------------
-	
+
 	  // Backbone Views are almost more convention than they are actual code. A View
 	  // is simply a JavaScript object that represents a logical chunk of UI in the
 	  // DOM. This might be a single item, an entire list, a sidebar or panel, or
@@ -11605,7 +11564,7 @@
 	  // UI as a **View** allows you to define your DOM events declaratively, without
 	  // having to worry about render order ... and makes it easy for the view to
 	  // react to specific changes in the state of your models.
-	
+
 	  // Creating a Backbone.View creates its initial element outside of the DOM,
 	  // if an existing element is not provided...
 	  var View = Backbone.View = function(options) {
@@ -11615,36 +11574,36 @@
 	    this.initialize.apply(this, arguments);
 	    this.delegateEvents();
 	  };
-	
+
 	  // Cached regex to split keys for `delegate`.
 	  var delegateEventSplitter = /^(\S+)\s*(.*)$/;
-	
+
 	  // List of view options to be merged as properties.
 	  var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
-	
+
 	  // Set up all inheritable **Backbone.View** properties and methods.
 	  _.extend(View.prototype, Events, {
-	
+
 	    // The default `tagName` of a View's element is `"div"`.
 	    tagName: 'div',
-	
+
 	    // jQuery delegate for element lookup, scoped to DOM elements within the
 	    // current view. This should be prefered to global lookups where possible.
 	    $: function(selector) {
 	      return this.$el.find(selector);
 	    },
-	
+
 	    // Initialize is an empty function by default. Override it with your own
 	    // initialization logic.
 	    initialize: function(){},
-	
+
 	    // **render** is the core function that your view should override, in order
 	    // to populate its element (`this.el`), with the appropriate HTML. The
 	    // convention is for **render** to always return `this`.
 	    render: function() {
 	      return this;
 	    },
-	
+
 	    // Remove this view by taking the element out of the DOM, and removing any
 	    // applicable Backbone.Events listeners.
 	    remove: function() {
@@ -11652,7 +11611,7 @@
 	      this.stopListening();
 	      return this;
 	    },
-	
+
 	    // Change the view's element (`this.el` property), including event
 	    // re-delegation.
 	    setElement: function(element, delegate) {
@@ -11662,7 +11621,7 @@
 	      if (delegate !== false) this.delegateEvents();
 	      return this;
 	    },
-	
+
 	    // Set callbacks, where `this.events` is a hash of
 	    //
 	    // *{"event selector": "callback"}*
@@ -11685,7 +11644,7 @@
 	        var method = events[key];
 	        if (!_.isFunction(method)) method = this[events[key]];
 	        if (!method) continue;
-	
+
 	        var match = key.match(delegateEventSplitter);
 	        var eventName = match[1], selector = match[2];
 	        method = _.bind(method, this);
@@ -11698,7 +11657,7 @@
 	      }
 	      return this;
 	    },
-	
+
 	    // Clears all callbacks previously bound to the view with `delegateEvents`.
 	    // You usually don't need to use this, but may wish to if you have multiple
 	    // Backbone views attached to the same DOM element.
@@ -11706,7 +11665,7 @@
 	      this.$el.off('.delegateEvents' + this.cid);
 	      return this;
 	    },
-	
+
 	    // Performs the initial configuration of a View with a set of options.
 	    // Keys with special meaning *(e.g. model, collection, id, className)* are
 	    // attached directly to the view.  See `viewOptions` for an exhaustive
@@ -11716,7 +11675,7 @@
 	      _.extend(this, _.pick(options, viewOptions));
 	      this.options = options;
 	    },
-	
+
 	    // Ensure that the View has a DOM element to render into.
 	    // If `this.el` is a string, pass it through `$()`, take the first
 	    // matching element, and re-assign it to `el`. Otherwise, create
@@ -11732,12 +11691,12 @@
 	        this.setElement(_.result(this, 'el'), false);
 	      }
 	    }
-	
+
 	  });
-	
+
 	  // Backbone.sync
 	  // -------------
-	
+
 	  // Override this function to change the manner in which Backbone persists
 	  // models to the server. You will be passed the type of request, and the
 	  // model in question. By default, makes a RESTful Ajax request
@@ -11755,33 +11714,33 @@
 	  // it difficult to read the body of `PUT` requests.
 	  Backbone.sync = function(method, model, options) {
 	    var type = methodMap[method];
-	
+
 	    // Default options, unless specified.
 	    _.defaults(options || (options = {}), {
 	      emulateHTTP: Backbone.emulateHTTP,
 	      emulateJSON: Backbone.emulateJSON
 	    });
-	
+
 	    // Default JSON-request options.
 	    var params = {type: type, dataType: 'json'};
-	
+
 	    // Ensure that we have a URL.
 	    if (!options.url) {
 	      params.url = _.result(model, 'url') || urlError();
 	    }
-	
+
 	    // Ensure that we have the appropriate request data.
 	    if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
 	      params.contentType = 'application/json';
 	      params.data = JSON.stringify(options.attrs || model.toJSON(options));
 	    }
-	
+
 	    // For older servers, emulate JSON by encoding the request into an HTML-form.
 	    if (options.emulateJSON) {
 	      params.contentType = 'application/x-www-form-urlencoded';
 	      params.data = params.data ? {model: params.data} : {};
 	    }
-	
+
 	    // For older servers, emulate HTTP by mimicking the HTTP method with `_method`
 	    // And an `X-HTTP-Method-Override` header.
 	    if (options.emulateHTTP && (type === 'PUT' || type === 'DELETE' || type === 'PATCH')) {
@@ -11793,12 +11752,12 @@
 	        if (beforeSend) return beforeSend.apply(this, arguments);
 	      };
 	    }
-	
+
 	    // Don't process data on a non-GET request.
 	    if (params.type !== 'GET' && !options.emulateJSON) {
 	      params.processData = false;
 	    }
-	
+
 	    // If we're sending a `PATCH` request, and we're in an old Internet Explorer
 	    // that still has ActiveX enabled by default, override jQuery to use that
 	    // for XHR instead. Remove this line when jQuery supports `PATCH` on IE8.
@@ -11808,13 +11767,13 @@
 	        return new ActiveXObject("Microsoft.XMLHTTP");
 	      };
 	    }
-	
+
 	    // Make the request, allowing the user to override any Ajax options.
 	    var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
 	    model.trigger('request', model, xhr, options);
 	    return xhr;
 	  };
-	
+
 	  // Map from CRUD to HTTP for our default `Backbone.sync` implementation.
 	  var methodMap = {
 	    'create': 'POST',
@@ -11823,16 +11782,16 @@
 	    'delete': 'DELETE',
 	    'read':   'GET'
 	  };
-	
+
 	  // Set the default implementation of `Backbone.ajax` to proxy through to `$`.
 	  // Override this if you'd like to use a different library.
 	  Backbone.ajax = function() {
 	    return Backbone.$.ajax.apply(Backbone.$, arguments);
 	  };
-	
+
 	  // Backbone.Router
 	  // ---------------
-	
+
 	  // Routers map faux-URLs to actions, and fire events when routes are
 	  // matched. Creating a new one sets its `routes` hash, if not set statically.
 	  var Router = Backbone.Router = function(options) {
@@ -11841,21 +11800,21 @@
 	    this._bindRoutes();
 	    this.initialize.apply(this, arguments);
 	  };
-	
+
 	  // Cached regular expressions for matching named param parts and splatted
 	  // parts of route strings.
 	  var optionalParam = /\((.*?)\)/g;
 	  var namedParam    = /(\(\?)?:\w+/g;
 	  var splatParam    = /\*\w+/g;
 	  var escapeRegExp  = /[\-{}\[\]+?.,\\\^$|#\s]/g;
-	
+
 	  // Set up all inheritable **Backbone.Router** properties and methods.
 	  _.extend(Router.prototype, Events, {
-	
+
 	    // Initialize is an empty function by default. Override it with your own
 	    // initialization logic.
 	    initialize: function(){},
-	
+
 	    // Manually bind a single named route to a callback. For example:
 	    //
 	    //     this.route('search/:query/p:num', 'search', function(query, num) {
@@ -11879,13 +11838,13 @@
 	      });
 	      return this;
 	    },
-	
+
 	    // Simple proxy to `Backbone.history` to save a fragment into the history.
 	    navigate: function(fragment, options) {
 	      Backbone.history.navigate(fragment, options);
 	      return this;
 	    },
-	
+
 	    // Bind all defined routes to `Backbone.history`. We have to reverse the
 	    // order of the routes here to support behavior where the most general
 	    // routes can be defined at the bottom of the route map.
@@ -11897,7 +11856,7 @@
 	        this.route(route, this.routes[route]);
 	      }
 	    },
-	
+
 	    // Convert a route string into a regular expression, suitable for matching
 	    // against the current location hash.
 	    _routeToRegExp: function(route) {
@@ -11909,7 +11868,7 @@
 	                   .replace(splatParam, '(.*?)');
 	      return new RegExp('^' + route + '$');
 	    },
-	
+
 	    // Given a route, and a URL fragment that it matches, return the array of
 	    // extracted decoded parameters. Empty or unmatched parameters will be
 	    // treated as `null` to normalize cross-browser behavior.
@@ -11919,12 +11878,12 @@
 	        return param ? decodeURIComponent(param) : null;
 	      });
 	    }
-	
+
 	  });
-	
+
 	  // Backbone.History
 	  // ----------------
-	
+
 	  // Handles cross-browser history management, based on either
 	  // [pushState](http://diveintohtml5.info/history.html) and real URLs, or
 	  // [onhashchange](https://developer.mozilla.org/en-US/docs/DOM/window.onhashchange)
@@ -11933,43 +11892,43 @@
 	  var History = Backbone.History = function() {
 	    this.handlers = [];
 	    _.bindAll(this, 'checkUrl');
-	
+
 	    // Ensure that `History` can be used outside of the browser.
 	    if (typeof window !== 'undefined') {
 	      this.location = window.location;
 	      this.history = window.history;
 	    }
 	  };
-	
+
 	  // Cached regex for stripping a leading hash/slash and trailing space.
 	  var routeStripper = /^[#\/]|\s+$/g;
-	
+
 	  // Cached regex for stripping leading and trailing slashes.
 	  var rootStripper = /^\/+|\/+$/g;
-	
+
 	  // Cached regex for detecting MSIE.
 	  var isExplorer = /msie [\w.]+/;
-	
+
 	  // Cached regex for removing a trailing slash.
 	  var trailingSlash = /\/$/;
-	
+
 	  // Has the history handling already been started?
 	  History.started = false;
-	
+
 	  // Set up all inheritable **Backbone.History** properties and methods.
 	  _.extend(History.prototype, Events, {
-	
+
 	    // The default interval to poll for hash changes, if necessary, is
 	    // twenty times a second.
 	    interval: 50,
-	
+
 	    // Gets the true hash value. Cannot use location.hash directly due to bug
 	    // in Firefox where location.hash will always be decoded.
 	    getHash: function(window) {
 	      var match = (window || this).location.href.match(/#(.*)$/);
 	      return match ? match[1] : '';
 	    },
-	
+
 	    // Get the cross-browser normalized URL fragment, either from the URL,
 	    // the hash, or the override.
 	    getFragment: function(fragment, forcePushState) {
@@ -11984,13 +11943,13 @@
 	      }
 	      return fragment.replace(routeStripper, '');
 	    },
-	
+
 	    // Start the hash change handling, returning `true` if the current URL matches
 	    // an existing route, and `false` otherwise.
 	    start: function(options) {
 	      if (History.started) throw new Error("Backbone.history has already been started");
 	      History.started = true;
-	
+
 	      // Figure out the initial configuration. Do we need an iframe?
 	      // Is pushState desired ... is it available?
 	      this.options          = _.extend({}, {root: '/'}, this.options, options);
@@ -12001,15 +11960,15 @@
 	      var fragment          = this.getFragment();
 	      var docMode           = document.documentMode;
 	      var oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) && (!docMode || docMode <= 7));
-	
+
 	      // Normalize root to always include a leading and trailing slash.
 	      this.root = ('/' + this.root + '/').replace(rootStripper, '/');
-	
+
 	      if (oldIE && this._wantsHashChange) {
 	        this.iframe = Backbone.$('<iframe src="javascript:0" tabindex="-1" />').hide().appendTo('body')[0].contentWindow;
 	        this.navigate(fragment);
 	      }
-	
+
 	      // Depending on whether we're using pushState or hashes, and whether
 	      // 'onhashchange' is supported, determine how we check the URL state.
 	      if (this._hasPushState) {
@@ -12019,13 +11978,13 @@
 	      } else if (this._wantsHashChange) {
 	        this._checkUrlInterval = setInterval(this.checkUrl, this.interval);
 	      }
-	
+
 	      // Determine if we need to change the base url, for a pushState link
 	      // opened by a non-pushState browser.
 	      this.fragment = fragment;
 	      var loc = this.location;
 	      var atRoot = loc.pathname.replace(/[^\/]$/, '$&/') === this.root;
-	
+
 	      // If we've started off with a route from a `pushState`-enabled browser,
 	      // but we're currently in a browser that doesn't support it...
 	      if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot) {
@@ -12033,17 +11992,17 @@
 	        this.location.replace(this.root + this.location.search + '#' + this.fragment);
 	        // Return immediately as browser will do redirect to new url
 	        return true;
-	
+
 	      // Or if we've started out with a hash-based route, but we're currently
 	      // in a browser where it could be `pushState`-based instead...
 	      } else if (this._wantsPushState && this._hasPushState && atRoot && loc.hash) {
 	        this.fragment = this.getHash().replace(routeStripper, '');
 	        this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
 	      }
-	
+
 	      if (!this.options.silent) return this.loadUrl();
 	    },
-	
+
 	    // Disable Backbone.history, perhaps temporarily. Not useful in a real app,
 	    // but possibly useful for unit testing Routers.
 	    stop: function() {
@@ -12051,13 +12010,13 @@
 	      clearInterval(this._checkUrlInterval);
 	      History.started = false;
 	    },
-	
+
 	    // Add a route to be tested when the fragment changes. Routes added later
 	    // may override previous routes.
 	    route: function(route, callback) {
 	      this.handlers.unshift({route: route, callback: callback});
 	    },
-	
+
 	    // Checks the current URL to see if it has changed, and if it has,
 	    // calls `loadUrl`, normalizing across the hidden iframe.
 	    checkUrl: function(e) {
@@ -12069,7 +12028,7 @@
 	      if (this.iframe) this.navigate(current);
 	      this.loadUrl() || this.loadUrl(this.getHash());
 	    },
-	
+
 	    // Attempt to load the current URL fragment. If a route succeeds with a
 	    // match, returns `true`. If no defined routes matches the fragment,
 	    // returns `false`.
@@ -12083,7 +12042,7 @@
 	      });
 	      return matched;
 	    },
-	
+
 	    // Save a fragment into the hash history, or replace the URL state if the
 	    // 'replace' option is passed. You are responsible for properly URL-encoding
 	    // the fragment in advance.
@@ -12098,11 +12057,11 @@
 	      if (this.fragment === fragment) return;
 	      this.fragment = fragment;
 	      var url = this.root + fragment;
-	
+
 	      // If pushState is available, we use it to set the fragment as a real URL.
 	      if (this._hasPushState) {
 	        this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
-	
+
 	      // If hash changes haven't been explicitly disabled, update the hash
 	      // fragment to store history.
 	      } else if (this._wantsHashChange) {
@@ -12114,7 +12073,7 @@
 	          if(!options.replace) this.iframe.document.open().close();
 	          this._updateHash(this.iframe.location, fragment, options.replace);
 	        }
-	
+
 	      // If you've told us that you explicitly don't want fallback hashchange-
 	      // based history, then `navigate` becomes a page refresh.
 	      } else {
@@ -12122,7 +12081,7 @@
 	      }
 	      if (options.trigger) this.loadUrl(fragment);
 	    },
-	
+
 	    // Update the hash location, either replacing the current entry, or adding
 	    // a new one to the browser history.
 	    _updateHash: function(location, fragment, replace) {
@@ -12134,22 +12093,22 @@
 	        location.hash = '#' + fragment;
 	      }
 	    }
-	
+
 	  });
-	
+
 	  // Create the default Backbone.history.
 	  Backbone.history = new History;
-	
+
 	  // Helpers
 	  // -------
-	
+
 	  // Helper function to correctly set up the prototype chain, for subclasses.
 	  // Similar to `goog.inherits`, but uses a hash of prototype properties and
 	  // class properties to be extended.
 	  var extend = function(protoProps, staticProps) {
 	    var parent = this;
 	    var child;
-	
+
 	    // The constructor function for the new subclass is either defined by you
 	    // (the "constructor" property in your `extend` definition), or defaulted
 	    // by us to simply call the parent's constructor.
@@ -12158,35 +12117,35 @@
 	    } else {
 	      child = function(){ return parent.apply(this, arguments); };
 	    }
-	
+
 	    // Add static properties to the constructor function, if supplied.
 	    _.extend(child, parent, staticProps);
-	
+
 	    // Set the prototype chain to inherit from `parent`, without calling
 	    // `parent`'s constructor function.
 	    var Surrogate = function(){ this.constructor = child; };
 	    Surrogate.prototype = parent.prototype;
 	    child.prototype = new Surrogate;
-	
+
 	    // Add prototype properties (instance properties) to the subclass,
 	    // if supplied.
 	    if (protoProps) _.extend(child.prototype, protoProps);
-	
+
 	    // Set a convenience property in case the parent's prototype is needed
 	    // later.
 	    child.__super__ = parent.prototype;
-	
+
 	    return child;
 	  };
-	
+
 	  // Set up inheritance for the model, collection, router, view and history.
 	  Model.extend = Collection.extend = Router.extend = View.extend = History.extend = extend;
-	
+
 	  // Throw an error when a URL is needed, and none is supplied.
 	  var urlError = function() {
 	    throw new Error('A "url" property or function must be specified');
 	  };
-	
+
 	  // Wrap an optional error callback with a fallback error event.
 	  var wrapError = function (model, options) {
 	    var error = options.error;
@@ -12195,37 +12154,37 @@
 	      model.trigger('error', model, resp, options);
 	    };
 	  };
-	
+
 	}).call(this);
-	
+
 
 /***/ },
-
-/***/ 8:
+/* 6 */,
+/* 7 */
 /***/ function(module, exports, require) {
 
-	/* WEBPACK VAR INJECTION */(function(require, module) {//     Underscore.js 1.5.2
+	//     Underscore.js 1.5.2
 	//     http://underscorejs.org
 	//     (c) 2009-2013 Jeremy Ashkenas, DocumentCloud and Investigative Reporters & Editors
 	//     Underscore may be freely distributed under the MIT license.
-	
+
 	(function() {
-	
+
 	  // Baseline setup
 	  // --------------
-	
+
 	  // Establish the root object, `window` in the browser, or `exports` on the server.
 	  var root = this;
-	
+
 	  // Save the previous value of the `_` variable.
 	  var previousUnderscore = root._;
-	
+
 	  // Establish the object that gets returned to break out of a loop iteration.
 	  var breaker = {};
-	
+
 	  // Save bytes in the minified (but not gzipped) version:
 	  var ArrayProto = Array.prototype, ObjProto = Object.prototype, FuncProto = Function.prototype;
-	
+
 	  // Create quick reference variables for speed access to core prototypes.
 	  var
 	    push             = ArrayProto.push,
@@ -12233,7 +12192,7 @@
 	    concat           = ArrayProto.concat,
 	    toString         = ObjProto.toString,
 	    hasOwnProperty   = ObjProto.hasOwnProperty;
-	
+
 	  // All **ECMAScript 5** native function implementations that we hope to use
 	  // are declared here.
 	  var
@@ -12249,14 +12208,14 @@
 	    nativeIsArray      = Array.isArray,
 	    nativeKeys         = Object.keys,
 	    nativeBind         = FuncProto.bind;
-	
+
 	  // Create a safe reference to the Underscore object for use below.
 	  var _ = function(obj) {
 	    if (obj instanceof _) return obj;
 	    if (!(this instanceof _)) return new _(obj);
 	    this._wrapped = obj;
 	  };
-	
+
 	  // Export the Underscore object for **Node.js**, with
 	  // backwards-compatibility for the old `require()` API. If we're in
 	  // the browser, add `_` as a global object via a string identifier,
@@ -12269,13 +12228,13 @@
 	  } else {
 	    root._ = _;
 	  }
-	
+
 	  // Current version.
 	  _.VERSION = '1.5.2';
-	
+
 	  // Collection Functions
 	  // --------------------
-	
+
 	  // The cornerstone, an `each` implementation, aka `forEach`.
 	  // Handles objects with the built-in `forEach`, arrays, and raw objects.
 	  // Delegates to **ECMAScript 5**'s native `forEach` if available.
@@ -12294,7 +12253,7 @@
 	      }
 	    }
 	  };
-	
+
 	  // Return the results of applying the iterator to each element.
 	  // Delegates to **ECMAScript 5**'s native `map` if available.
 	  _.map = _.collect = function(obj, iterator, context) {
@@ -12306,9 +12265,9 @@
 	    });
 	    return results;
 	  };
-	
+
 	  var reduceError = 'Reduce of empty array with no initial value';
-	
+
 	  // **Reduce** builds up a single result from a list of values, aka `inject`,
 	  // or `foldl`. Delegates to **ECMAScript 5**'s native `reduce` if available.
 	  _.reduce = _.foldl = _.inject = function(obj, iterator, memo, context) {
@@ -12329,7 +12288,7 @@
 	    if (!initial) throw new TypeError(reduceError);
 	    return memo;
 	  };
-	
+
 	  // The right-associative version of reduce, also known as `foldr`.
 	  // Delegates to **ECMAScript 5**'s native `reduceRight` if available.
 	  _.reduceRight = _.foldr = function(obj, iterator, memo, context) {
@@ -12356,7 +12315,7 @@
 	    if (!initial) throw new TypeError(reduceError);
 	    return memo;
 	  };
-	
+
 	  // Return the first value which passes a truth test. Aliased as `detect`.
 	  _.find = _.detect = function(obj, iterator, context) {
 	    var result;
@@ -12368,7 +12327,7 @@
 	    });
 	    return result;
 	  };
-	
+
 	  // Return all the elements that pass a truth test.
 	  // Delegates to **ECMAScript 5**'s native `filter` if available.
 	  // Aliased as `select`.
@@ -12381,14 +12340,14 @@
 	    });
 	    return results;
 	  };
-	
+
 	  // Return all the elements for which a truth test fails.
 	  _.reject = function(obj, iterator, context) {
 	    return _.filter(obj, function(value, index, list) {
 	      return !iterator.call(context, value, index, list);
 	    }, context);
 	  };
-	
+
 	  // Determine whether all of the elements match a truth test.
 	  // Delegates to **ECMAScript 5**'s native `every` if available.
 	  // Aliased as `all`.
@@ -12402,7 +12361,7 @@
 	    });
 	    return !!result;
 	  };
-	
+
 	  // Determine if at least one element in the object matches a truth test.
 	  // Delegates to **ECMAScript 5**'s native `some` if available.
 	  // Aliased as `any`.
@@ -12416,7 +12375,7 @@
 	    });
 	    return !!result;
 	  };
-	
+
 	  // Determine if the array or object contains a given value (using `===`).
 	  // Aliased as `include`.
 	  _.contains = _.include = function(obj, target) {
@@ -12426,7 +12385,7 @@
 	      return value === target;
 	    });
 	  };
-	
+
 	  // Invoke a method (with arguments) on every item in a collection.
 	  _.invoke = function(obj, method) {
 	    var args = slice.call(arguments, 2);
@@ -12435,12 +12394,12 @@
 	      return (isFunc ? method : value[method]).apply(value, args);
 	    });
 	  };
-	
+
 	  // Convenience version of a common use case of `map`: fetching a property.
 	  _.pluck = function(obj, key) {
 	    return _.map(obj, function(value){ return value[key]; });
 	  };
-	
+
 	  // Convenience version of a common use case of `filter`: selecting only objects
 	  // containing specific `key:value` pairs.
 	  _.where = function(obj, attrs, first) {
@@ -12452,13 +12411,13 @@
 	      return true;
 	    });
 	  };
-	
+
 	  // Convenience version of a common use case of `find`: getting the first object
 	  // containing specific `key:value` pairs.
 	  _.findWhere = function(obj, attrs) {
 	    return _.where(obj, attrs, true);
 	  };
-	
+
 	  // Return the maximum element or (element-based computation).
 	  // Can't optimize arrays of integers longer than 65,535 elements.
 	  // See [WebKit Bug 80797](https://bugs.webkit.org/show_bug.cgi?id=80797)
@@ -12474,7 +12433,7 @@
 	    });
 	    return result.value;
 	  };
-	
+
 	  // Return the minimum element (or element-based computation).
 	  _.min = function(obj, iterator, context) {
 	    if (!iterator && _.isArray(obj) && obj[0] === +obj[0] && obj.length < 65535) {
@@ -12488,7 +12447,7 @@
 	    });
 	    return result.value;
 	  };
-	
+
 	  // Shuffle an array, using the modern version of the 
 	  // [Fisher-Yates shuffle](http://en.wikipedia.org/wiki/Fisher–Yates_shuffle).
 	  _.shuffle = function(obj) {
@@ -12502,7 +12461,7 @@
 	    });
 	    return shuffled;
 	  };
-	
+
 	  // Sample **n** random values from an array.
 	  // If **n** is not specified, returns a single random element from the array.
 	  // The internal `guard` argument allows it to work with `map`.
@@ -12512,12 +12471,12 @@
 	    }
 	    return _.shuffle(obj).slice(0, Math.max(0, n));
 	  };
-	
+
 	  // An internal function to generate lookup iterators.
 	  var lookupIterator = function(value) {
 	    return _.isFunction(value) ? value : function(obj){ return obj[value]; };
 	  };
-	
+
 	  // Sort the object's values by a criterion produced by an iterator.
 	  _.sortBy = function(obj, value, context) {
 	    var iterator = lookupIterator(value);
@@ -12537,7 +12496,7 @@
 	      return left.index - right.index;
 	    }), 'value');
 	  };
-	
+
 	  // An internal function used for aggregate "group by" operations.
 	  var group = function(behavior) {
 	    return function(obj, value, context) {
@@ -12550,26 +12509,26 @@
 	      return result;
 	    };
 	  };
-	
+
 	  // Groups the object's values by a criterion. Pass either a string attribute
 	  // to group by, or a function that returns the criterion.
 	  _.groupBy = group(function(result, key, value) {
 	    (_.has(result, key) ? result[key] : (result[key] = [])).push(value);
 	  });
-	
+
 	  // Indexes the object's values by a criterion, similar to `groupBy`, but for
 	  // when you know that your index values will be unique.
 	  _.indexBy = group(function(result, key, value) {
 	    result[key] = value;
 	  });
-	
+
 	  // Counts instances of an object that group by a certain criterion. Pass
 	  // either a string attribute to count by, or a function that returns the
 	  // criterion.
 	  _.countBy = group(function(result, key) {
 	    _.has(result, key) ? result[key]++ : result[key] = 1;
 	  });
-	
+
 	  // Use a comparator function to figure out the smallest index at which
 	  // an object should be inserted so as to maintain order. Uses binary search.
 	  _.sortedIndex = function(array, obj, iterator, context) {
@@ -12582,7 +12541,7 @@
 	    }
 	    return low;
 	  };
-	
+
 	  // Safely create a real, live array from anything iterable.
 	  _.toArray = function(obj) {
 	    if (!obj) return [];
@@ -12590,16 +12549,16 @@
 	    if (obj.length === +obj.length) return _.map(obj, _.identity);
 	    return _.values(obj);
 	  };
-	
+
 	  // Return the number of elements in an object.
 	  _.size = function(obj) {
 	    if (obj == null) return 0;
 	    return (obj.length === +obj.length) ? obj.length : _.keys(obj).length;
 	  };
-	
+
 	  // Array Functions
 	  // ---------------
-	
+
 	  // Get the first element of an array. Passing **n** will return the first N
 	  // values in the array. Aliased as `head` and `take`. The **guard** check
 	  // allows it to work with `_.map`.
@@ -12607,7 +12566,7 @@
 	    if (array == null) return void 0;
 	    return (n == null) || guard ? array[0] : slice.call(array, 0, n);
 	  };
-	
+
 	  // Returns everything but the last entry of the array. Especially useful on
 	  // the arguments object. Passing **n** will return all the values in
 	  // the array, excluding the last N. The **guard** check allows it to work with
@@ -12615,7 +12574,7 @@
 	  _.initial = function(array, n, guard) {
 	    return slice.call(array, 0, array.length - ((n == null) || guard ? 1 : n));
 	  };
-	
+
 	  // Get the last element of an array. Passing **n** will return the last N
 	  // values in the array. The **guard** check allows it to work with `_.map`.
 	  _.last = function(array, n, guard) {
@@ -12626,7 +12585,7 @@
 	      return slice.call(array, Math.max(array.length - n, 0));
 	    }
 	  };
-	
+
 	  // Returns everything but the first entry of the array. Aliased as `tail` and `drop`.
 	  // Especially useful on the arguments object. Passing an **n** will return
 	  // the rest N values in the array. The **guard**
@@ -12634,12 +12593,12 @@
 	  _.rest = _.tail = _.drop = function(array, n, guard) {
 	    return slice.call(array, (n == null) || guard ? 1 : n);
 	  };
-	
+
 	  // Trim out all falsy values from an array.
 	  _.compact = function(array) {
 	    return _.filter(array, _.identity);
 	  };
-	
+
 	  // Internal implementation of a recursive `flatten` function.
 	  var flatten = function(input, shallow, output) {
 	    if (shallow && _.every(input, _.isArray)) {
@@ -12654,17 +12613,17 @@
 	    });
 	    return output;
 	  };
-	
+
 	  // Flatten out an array, either recursively (by default), or just one level.
 	  _.flatten = function(array, shallow) {
 	    return flatten(array, shallow, []);
 	  };
-	
+
 	  // Return a version of the array that does not contain the specified value(s).
 	  _.without = function(array) {
 	    return _.difference(array, slice.call(arguments, 1));
 	  };
-	
+
 	  // Produce a duplicate-free version of the array. If the array has already
 	  // been sorted, you have the option of using a faster algorithm.
 	  // Aliased as `unique`.
@@ -12685,13 +12644,13 @@
 	    });
 	    return results;
 	  };
-	
+
 	  // Produce an array that contains the union: each distinct element from all of
 	  // the passed-in arrays.
 	  _.union = function() {
 	    return _.uniq(_.flatten(arguments, true));
 	  };
-	
+
 	  // Produce an array that contains every item shared between all the
 	  // passed-in arrays.
 	  _.intersection = function(array) {
@@ -12702,14 +12661,14 @@
 	      });
 	    });
 	  };
-	
+
 	  // Take the difference between one array and a number of other arrays.
 	  // Only the elements present in just the first array will remain.
 	  _.difference = function(array) {
 	    var rest = concat.apply(ArrayProto, slice.call(arguments, 1));
 	    return _.filter(array, function(value){ return !_.contains(rest, value); });
 	  };
-	
+
 	  // Zip together multiple lists into a single array -- elements that share
 	  // an index go together.
 	  _.zip = function() {
@@ -12720,7 +12679,7 @@
 	    }
 	    return results;
 	  };
-	
+
 	  // Converts lists into objects. Pass either a single array of `[key, value]`
 	  // pairs, or two parallel arrays of the same length -- one of keys, and one of
 	  // the corresponding values.
@@ -12736,7 +12695,7 @@
 	    }
 	    return result;
 	  };
-	
+
 	  // If the browser doesn't supply us with indexOf (I'm looking at you, **MSIE**),
 	  // we need this function. Return the position of the first occurrence of an
 	  // item in an array, or -1 if the item is not included in the array.
@@ -12758,7 +12717,7 @@
 	    for (; i < length; i++) if (array[i] === item) return i;
 	    return -1;
 	  };
-	
+
 	  // Delegates to **ECMAScript 5**'s native `lastIndexOf` if available.
 	  _.lastIndexOf = function(array, item, from) {
 	    if (array == null) return -1;
@@ -12770,7 +12729,7 @@
 	    while (i--) if (array[i] === item) return i;
 	    return -1;
 	  };
-	
+
 	  // Generate an integer Array containing an arithmetic progression. A port of
 	  // the native Python `range()` function. See
 	  // [the Python documentation](http://docs.python.org/library/functions.html#range).
@@ -12780,25 +12739,25 @@
 	      start = 0;
 	    }
 	    step = arguments[2] || 1;
-	
+
 	    var length = Math.max(Math.ceil((stop - start) / step), 0);
 	    var idx = 0;
 	    var range = new Array(length);
-	
+
 	    while(idx < length) {
 	      range[idx++] = start;
 	      start += step;
 	    }
-	
+
 	    return range;
 	  };
-	
+
 	  // Function (ahem) Functions
 	  // ------------------
-	
+
 	  // Reusable constructor function for prototype setting.
 	  var ctor = function(){};
-	
+
 	  // Create a function bound to a given object (assigning `this`, and arguments,
 	  // optionally). Delegates to **ECMAScript 5**'s native `Function.bind` if
 	  // available.
@@ -12817,7 +12776,7 @@
 	      return self;
 	    };
 	  };
-	
+
 	  // Partially apply a function by creating a version that has had some of its
 	  // arguments pre-filled, without changing its dynamic `this` context.
 	  _.partial = function(func) {
@@ -12826,7 +12785,7 @@
 	      return func.apply(this, args.concat(slice.call(arguments)));
 	    };
 	  };
-	
+
 	  // Bind all of an object's methods to that object. Useful for ensuring that
 	  // all callbacks defined on an object belong to it.
 	  _.bindAll = function(obj) {
@@ -12835,7 +12794,7 @@
 	    each(funcs, function(f) { obj[f] = _.bind(obj[f], obj); });
 	    return obj;
 	  };
-	
+
 	  // Memoize an expensive function by storing its results.
 	  _.memoize = function(func, hasher) {
 	    var memo = {};
@@ -12845,20 +12804,20 @@
 	      return _.has(memo, key) ? memo[key] : (memo[key] = func.apply(this, arguments));
 	    };
 	  };
-	
+
 	  // Delays a function for the given number of milliseconds, and then calls
 	  // it with the arguments supplied.
 	  _.delay = function(func, wait) {
 	    var args = slice.call(arguments, 2);
 	    return setTimeout(function(){ return func.apply(null, args); }, wait);
 	  };
-	
+
 	  // Defers a function, scheduling it to run after the current call stack has
 	  // cleared.
 	  _.defer = function(func) {
 	    return _.delay.apply(_, [func, 1].concat(slice.call(arguments, 1)));
 	  };
-	
+
 	  // Returns a function, that, when invoked, will only be triggered at most once
 	  // during a given window of time. Normally, the throttled function will run
 	  // as much as it can, without ever going more than once per `wait` duration;
@@ -12891,7 +12850,7 @@
 	      return result;
 	    };
 	  };
-	
+
 	  // Returns a function, that, as long as it continues to be invoked, will not
 	  // be triggered. The function will be called after it stops being called for
 	  // N milliseconds. If `immediate` is passed, trigger the function on the
@@ -12919,7 +12878,7 @@
 	      return result;
 	    };
 	  };
-	
+
 	  // Returns a function that will be executed at most one time, no matter how
 	  // often you call it. Useful for lazy initialization.
 	  _.once = function(func) {
@@ -12932,7 +12891,7 @@
 	      return memo;
 	    };
 	  };
-	
+
 	  // Returns the first function passed as an argument to the second,
 	  // allowing you to adjust arguments, run code before and after, and
 	  // conditionally execute the original function.
@@ -12943,7 +12902,7 @@
 	      return wrapper.apply(this, args);
 	    };
 	  };
-	
+
 	  // Returns a function that is the composition of a list of functions, each
 	  // consuming the return value of the function that follows.
 	  _.compose = function() {
@@ -12956,7 +12915,7 @@
 	      return args[0];
 	    };
 	  };
-	
+
 	  // Returns a function that will only be executed after being called N times.
 	  _.after = function(times, func) {
 	    return function() {
@@ -12965,10 +12924,10 @@
 	      }
 	    };
 	  };
-	
+
 	  // Object Functions
 	  // ----------------
-	
+
 	  // Retrieve the names of an object's properties.
 	  // Delegates to **ECMAScript 5**'s native `Object.keys`
 	  _.keys = nativeKeys || function(obj) {
@@ -12977,7 +12936,7 @@
 	    for (var key in obj) if (_.has(obj, key)) keys.push(key);
 	    return keys;
 	  };
-	
+
 	  // Retrieve the values of an object's properties.
 	  _.values = function(obj) {
 	    var keys = _.keys(obj);
@@ -12988,7 +12947,7 @@
 	    }
 	    return values;
 	  };
-	
+
 	  // Convert an object into a list of `[key, value]` pairs.
 	  _.pairs = function(obj) {
 	    var keys = _.keys(obj);
@@ -12999,7 +12958,7 @@
 	    }
 	    return pairs;
 	  };
-	
+
 	  // Invert the keys and values of an object. The values must be serializable.
 	  _.invert = function(obj) {
 	    var result = {};
@@ -13009,7 +12968,7 @@
 	    }
 	    return result;
 	  };
-	
+
 	  // Return a sorted list of the function names available on the object.
 	  // Aliased as `methods`
 	  _.functions = _.methods = function(obj) {
@@ -13019,7 +12978,7 @@
 	    }
 	    return names.sort();
 	  };
-	
+
 	  // Extend a given object with all the properties in passed-in object(s).
 	  _.extend = function(obj) {
 	    each(slice.call(arguments, 1), function(source) {
@@ -13031,7 +12990,7 @@
 	    });
 	    return obj;
 	  };
-	
+
 	  // Return a copy of the object only containing the whitelisted properties.
 	  _.pick = function(obj) {
 	    var copy = {};
@@ -13041,7 +13000,7 @@
 	    });
 	    return copy;
 	  };
-	
+
 	   // Return a copy of the object without the blacklisted properties.
 	  _.omit = function(obj) {
 	    var copy = {};
@@ -13051,7 +13010,7 @@
 	    }
 	    return copy;
 	  };
-	
+
 	  // Fill in a given object with default properties.
 	  _.defaults = function(obj) {
 	    each(slice.call(arguments, 1), function(source) {
@@ -13063,13 +13022,13 @@
 	    });
 	    return obj;
 	  };
-	
+
 	  // Create a (shallow-cloned) duplicate of an object.
 	  _.clone = function(obj) {
 	    if (!_.isObject(obj)) return obj;
 	    return _.isArray(obj) ? obj.slice() : _.extend({}, obj);
 	  };
-	
+
 	  // Invokes interceptor with the obj, and then returns obj.
 	  // The primary purpose of this method is to "tap into" a method chain, in
 	  // order to perform operations on intermediate results within the chain.
@@ -13077,7 +13036,7 @@
 	    interceptor(obj);
 	    return obj;
 	  };
-	
+
 	  // Internal recursive comparison function for `isEqual`.
 	  var eq = function(a, b, aStack, bStack) {
 	    // Identical objects are equal. `0 === -0`, but they aren't identical.
@@ -13168,12 +13127,12 @@
 	    bStack.pop();
 	    return result;
 	  };
-	
+
 	  // Perform a deep comparison to check if two objects are equal.
 	  _.isEqual = function(a, b) {
 	    return eq(a, b, [], []);
 	  };
-	
+
 	  // Is a given array, string, or object empty?
 	  // An "empty" object has no enumerable own-properties.
 	  _.isEmpty = function(obj) {
@@ -13182,30 +13141,30 @@
 	    for (var key in obj) if (_.has(obj, key)) return false;
 	    return true;
 	  };
-	
+
 	  // Is a given value a DOM element?
 	  _.isElement = function(obj) {
 	    return !!(obj && obj.nodeType === 1);
 	  };
-	
+
 	  // Is a given value an array?
 	  // Delegates to ECMA5's native Array.isArray
 	  _.isArray = nativeIsArray || function(obj) {
 	    return toString.call(obj) == '[object Array]';
 	  };
-	
+
 	  // Is a given variable an object?
 	  _.isObject = function(obj) {
 	    return obj === Object(obj);
 	  };
-	
+
 	  // Add some isType methods: isArguments, isFunction, isString, isNumber, isDate, isRegExp.
 	  each(['Arguments', 'Function', 'String', 'Number', 'Date', 'RegExp'], function(name) {
 	    _['is' + name] = function(obj) {
 	      return toString.call(obj) == '[object ' + name + ']';
 	    };
 	  });
-	
+
 	  // Define a fallback version of the method in browsers (ahem, IE), where
 	  // there isn't any inspectable "Arguments" type.
 	  if (!_.isArguments(arguments)) {
@@ -13213,67 +13172,67 @@
 	      return !!(obj && _.has(obj, 'callee'));
 	    };
 	  }
-	
+
 	  // Optimize `isFunction` if appropriate.
 	  if (true) {
 	    _.isFunction = function(obj) {
 	      return typeof obj === 'function';
 	    };
 	  }
-	
+
 	  // Is a given object a finite number?
 	  _.isFinite = function(obj) {
 	    return isFinite(obj) && !isNaN(parseFloat(obj));
 	  };
-	
+
 	  // Is the given value `NaN`? (NaN is the only number which does not equal itself).
 	  _.isNaN = function(obj) {
 	    return _.isNumber(obj) && obj != +obj;
 	  };
-	
+
 	  // Is a given value a boolean?
 	  _.isBoolean = function(obj) {
 	    return obj === true || obj === false || toString.call(obj) == '[object Boolean]';
 	  };
-	
+
 	  // Is a given value equal to null?
 	  _.isNull = function(obj) {
 	    return obj === null;
 	  };
-	
+
 	  // Is a given variable undefined?
 	  _.isUndefined = function(obj) {
 	    return obj === void 0;
 	  };
-	
+
 	  // Shortcut function for checking if an object has a given property directly
 	  // on itself (in other words, not on a prototype).
 	  _.has = function(obj, key) {
 	    return hasOwnProperty.call(obj, key);
 	  };
-	
+
 	  // Utility Functions
 	  // -----------------
-	
+
 	  // Run Underscore.js in *noConflict* mode, returning the `_` variable to its
 	  // previous owner. Returns a reference to the Underscore object.
 	  _.noConflict = function() {
 	    root._ = previousUnderscore;
 	    return this;
 	  };
-	
+
 	  // Keep the identity function around for default iterators.
 	  _.identity = function(value) {
 	    return value;
 	  };
-	
+
 	  // Run a function **n** times.
 	  _.times = function(n, iterator, context) {
 	    var accum = Array(Math.max(0, n));
 	    for (var i = 0; i < n; i++) accum[i] = iterator.call(context, i);
 	    return accum;
 	  };
-	
+
 	  // Return a random integer between min and max (inclusive).
 	  _.random = function(min, max) {
 	    if (max == null) {
@@ -13282,7 +13241,7 @@
 	    }
 	    return min + Math.floor(Math.random() * (max - min + 1));
 	  };
-	
+
 	  // List of HTML entities for escaping.
 	  var entityMap = {
 	    escape: {
@@ -13294,13 +13253,13 @@
 	    }
 	  };
 	  entityMap.unescape = _.invert(entityMap.escape);
-	
+
 	  // Regexes containing the keys and values listed immediately above.
 	  var entityRegexes = {
 	    escape:   new RegExp('[' + _.keys(entityMap.escape).join('') + ']', 'g'),
 	    unescape: new RegExp('(' + _.keys(entityMap.unescape).join('|') + ')', 'g')
 	  };
-	
+
 	  // Functions for escaping and unescaping strings to/from HTML interpolation.
 	  _.each(['escape', 'unescape'], function(method) {
 	    _[method] = function(string) {
@@ -13310,7 +13269,7 @@
 	      });
 	    };
 	  });
-	
+
 	  // If the value of the named `property` is a function then invoke it with the
 	  // `object` as context; otherwise, return it.
 	  _.result = function(object, property) {
@@ -13318,7 +13277,7 @@
 	    var value = object[property];
 	    return _.isFunction(value) ? value.call(object) : value;
 	  };
-	
+
 	  // Add your own custom functions to the Underscore object.
 	  _.mixin = function(obj) {
 	    each(_.functions(obj), function(name) {
@@ -13330,7 +13289,7 @@
 	      };
 	    });
 	  };
-	
+
 	  // Generate a unique integer id (unique within the entire client session).
 	  // Useful for temporary DOM ids.
 	  var idCounter = 0;
@@ -13338,7 +13297,7 @@
 	    var id = ++idCounter + '';
 	    return prefix ? prefix + id : id;
 	  };
-	
+
 	  // By default, Underscore uses ERB-style template delimiters, change the
 	  // following template settings to use alternative delimiters.
 	  _.templateSettings = {
@@ -13346,12 +13305,12 @@
 	    interpolate : /<%=([\s\S]+?)%>/g,
 	    escape      : /<%-([\s\S]+?)%>/g
 	  };
-	
+
 	  // When customizing `templateSettings`, if you don't want to define an
 	  // interpolation, evaluation or escaping regex, we need one that is
 	  // guaranteed not to match.
 	  var noMatch = /(.)^/;
-	
+
 	  // Certain characters need to be escaped so that they can be put into a
 	  // string literal.
 	  var escapes = {
@@ -13363,30 +13322,30 @@
 	    '\u2028': 'u2028',
 	    '\u2029': 'u2029'
 	  };
-	
+
 	  var escaper = /\\|'|\r|\n|\t|\u2028|\u2029/g;
-	
+
 	  // JavaScript micro-templating, similar to John Resig's implementation.
 	  // Underscore templating handles arbitrary delimiters, preserves whitespace,
 	  // and correctly escapes quotes within interpolated code.
 	  _.template = function(text, data, settings) {
 	    var render;
 	    settings = _.defaults({}, settings, _.templateSettings);
-	
+
 	    // Combine delimiters into one regular expression via alternation.
 	    var matcher = new RegExp([
 	      (settings.escape || noMatch).source,
 	      (settings.interpolate || noMatch).source,
 	      (settings.evaluate || noMatch).source
 	    ].join('|') + '|$', 'g');
-	
+
 	    // Compile the template source, escaping string literals appropriately.
 	    var index = 0;
 	    var source = "__p+='";
 	    text.replace(matcher, function(match, escape, interpolate, evaluate, offset) {
 	      source += text.slice(index, offset)
 	        .replace(escaper, function(match) { return '\\' + escapes[match]; });
-	
+
 	      if (escape) {
 	        source += "'+\n((__t=(" + escape + "))==null?'':_.escape(__t))+\n'";
 	      }
@@ -13400,51 +13359,51 @@
 	      return match;
 	    });
 	    source += "';\n";
-	
+
 	    // If a variable is not specified, place data values in local scope.
 	    if (!settings.variable) source = 'with(obj||{}){\n' + source + '}\n';
-	
+
 	    source = "var __t,__p='',__j=Array.prototype.join," +
 	      "print=function(){__p+=__j.call(arguments,'');};\n" +
 	      source + "return __p;\n";
-	
+
 	    try {
 	      render = new Function(settings.variable || 'obj', '_', source);
 	    } catch (e) {
 	      e.source = source;
 	      throw e;
 	    }
-	
+
 	    if (data) return render(data, _);
 	    var template = function(data) {
 	      return render.call(this, data, _);
 	    };
-	
+
 	    // Provide the compiled function source as a convenience for precompilation.
 	    template.source = 'function(' + (settings.variable || 'obj') + '){\n' + source + '}';
-	
+
 	    return template;
 	  };
-	
+
 	  // Add a "chain" function, which will delegate to the wrapper.
 	  _.chain = function(obj) {
 	    return _(obj).chain();
 	  };
-	
+
 	  // OOP
 	  // ---------------
 	  // If Underscore is called as a function, it returns a wrapped object that
 	  // can be used OO-style. This wrapper holds altered versions of all the
 	  // underscore functions. Wrapped objects may be chained.
-	
+
 	  // Helper function to continue chaining intermediate results.
 	  var result = function(obj) {
 	    return this._chain ? _(obj).chain() : obj;
 	  };
-	
+
 	  // Add all of the Underscore functions to the wrapper object.
 	  _.mixin(_);
-	
+
 	  // Add all mutator Array functions to the wrapper.
 	  each(['pop', 'push', 'reverse', 'shift', 'sort', 'splice', 'unshift'], function(name) {
 	    var method = ArrayProto[name];
@@ -13455,7 +13414,7 @@
 	      return result.call(this, obj);
 	    };
 	  });
-	
+
 	  // Add all accessor Array functions to the wrapper.
 	  each(['concat', 'join', 'slice'], function(name) {
 	    var method = ArrayProto[name];
@@ -13463,25 +13422,24 @@
 	      return result.call(this, method.apply(this._wrapped, arguments));
 	    };
 	  });
-	
+
 	  _.extend(_.prototype, {
-	
+
 	    // Start chaining a wrapped Underscore object.
 	    chain: function() {
 	      this._chain = true;
 	      return this;
 	    },
-	
+
 	    // Extracts the result from a wrapped and chained object.
 	    value: function() {
 	      return this._wrapped;
 	    }
-	
+
 	  });
-	
+
 	}).call(this);
-	
-	/* WEBPACK VAR INJECTION */}(require, require(5)(module)))
+
 
 /***/ }
-/******/ })
+/******/ ])

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  resolve: {
+    modulesDirectories: ['bower_components','node_modules']
+  }
+};


### PR DESCRIPTION
Following the instructions on the README was resulting in this error:

```
ERROR in ./bower_components/jquery.scrollTo/jquery.scrollTo.js
Module not found: Error: Cannot resolve module jquery in /tmp/tmp1456/webpack-intro/bower_components/jquery.scrollTo
 @ ./bower_components/jquery.scrollTo/jquery.scrollTo.js 14:8-35
```

Details:

```
fernando@fernando-E4300 /tmp/tmp1456 $ git clone https://github.com/davidgovea/webpack-intro.git
Cloning into 'webpack-intro'...
remote: Reusing existing pack: 36, done.
remote: Total 36 (delta 0), reused 0 (delta 0)
Unpacking objects: 100% (36/36), done.
Checking connectivity... done
fernando@fernando-E4300 /tmp/tmp1456 $ cd webpack-intro/
fernando@fernando-E4300 /tmp/tmp1456/webpack-intro $ npm install
(...)
hammerjs@1.0.6 node_modules/hammerjs

backbone@1.0.0 node_modules/backbone
└── underscore@1.5.2

webpack@0.11.18 node_modules/webpack
├── base64-encode@1.0.1
├── tapable@0.1.3
├── clone@0.1.11
├── async@0.2.9
├── mkdirp@0.3.5
├── enhanced-resolve@0.5.15
├── esprima@1.0.4
├── optimist@0.6.0 (wordwrap@0.0.2, minimist@0.0.5)
├── webpack-core@0.2.12 (source-map@0.1.31)
├── uglify-js@2.4.9 (uglify-to-browserify@1.0.1, optimist@0.3.7, source-map@0.1.31)
└── node-libs-browser@0.1.2 (console-browserify@0.1.6, zlib-browserify@0.0.1, vm-browserify@0.0.1, crypto-browserify@0.2.1, buffer-browserify@0.0.4, http-browserify@0.1.6)
fernando@fernando-E4300 /tmp/tmp1456/webpack-intro $ bower install
bower modernizr#~2.6.2          cached git://github.com/Modernizr/Modernizr.git#2.6.3
bower modernizr#~2.6.2        validate 2.6.3 against git://github.com/Modernizr/Modernizr.git#~2.6.2
bower jquery.scrollTo#~1.4.6    cached git://github.com/flesler/jquery.scrollTo.git#1.4.9
bower jquery.scrollTo#~1.4.6  validate 1.4.9 against git://github.com/flesler/jquery.scrollTo.git#~1.4.6
bower jquery#~2.0.3             cached git://github.com/components/jquery.git#2.0.3
bower jquery#~2.0.3           validate 2.0.3 against git://github.com/components/jquery.git#~2.0.3
bower jquery#>=1.8              cached git://github.com/components/jquery.git#2.0.3
bower jquery#>=1.8            validate 2.0.3 against git://github.com/components/jquery.git#>=1.8
bower jquery.scrollTo#~1.4.6   install jquery.scrollTo#1.4.9
bower jquery#~2.0.3            install jquery#2.0.3
bower modernizr#~2.6.2         install modernizr#2.6.3

jquery.scrollTo#1.4.9 bower_components/jquery.scrollTo
└── jquery#2.0.3

jquery#2.0.3 bower_components/jquery

modernizr#2.6.3 bower_components/modernizr
fernando@fernando-E4300 /tmp/tmp1456/webpack-intro $ make
Hash: b4335aa03db5af5e678e
Version: webpack 0.11.18
Time: 1795ms
      Asset    Size  Chunks             Chunk Names
  bundle.js  417618       0  [emitted]  main       
1.bundle.js   42731       1  [emitted]             
   [0] ./entry.js 1237 {0} [built]
   [1] ./bower_components/modernizr/modernizr.js 50144 {0} [built]
   [2] ./bower_components/jquery/jquery.js 242142 {0} [built]
   [3] ./bower_components/jquery.scrollTo/jquery.scrollTo.js 5353 {0} [built] [1 error]
   [4] (webpack)/buildin/module.js 251 {0} [built]
   [5] ./~/backbone/backbone.js 59498 {0} [built]
   [6] ./~/hammerjs/hammer.js 41337 {1} [built]
   [7] ./~/backbone/~/underscore/underscore.js 43566 {0} [built]

ERROR in ./bower_components/jquery.scrollTo/jquery.scrollTo.js
Module not found: Error: Cannot resolve module jquery in /tmp/tmp1456/webpack-intro/bower_components/jquery.scrollTo
 @ ./bower_components/jquery.scrollTo/jquery.scrollTo.js 14:8-35
```
